### PR TITLE
Disabled animation for folder expansion

### DIFF
--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -36,7 +36,7 @@ export class ProjectTreeComponent implements OnInit {
 
   nodes: ProjectStructure[];
   options = {
-    animateExpand: true,
+    animateExpand: false,
     actionMapping: {
       mouse: {
         // dblClick: (tree, node, $event) => {


### PR DESCRIPTION
The folder animation seems to be slowing the UI down a fair amount and I believe the expansion looks fine without the animation