### PR TITLE
Switched console log to zowe logger

### DIFF
--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -8,7 +8,8 @@
   
   Copyright Contributors to the Zowe Project.
 */
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 
 @Component({
   selector: 'app-root',
@@ -17,6 +18,10 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'app';
+  
+  constructor(@Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger) {
+    this.log.debug(`Monaco object=`,(<any>window).monaco);
+  }
 }
 
 /*

--- a/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.ts
+++ b/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.ts
@@ -8,9 +8,10 @@
   
   Copyright Contributors to the Zowe Project.
 */
-import { Component, OnInit, Input, Output, EventEmitter, Directive, HostListener } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, Directive, HostListener, Inject } from '@angular/core';
 import { ProjectContext } from '../../../shared/model/project-context';
 import { EditorControlService } from '../../../shared/editor-control/editor-control.service';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 
 @Component({
   selector: 'app-file-tabs',
@@ -44,12 +45,13 @@ export class FileTabsComponent implements OnInit {
 export class MouseMiddleClickDirective {
   @Input('fileContext') fileContext: ProjectContext;
   @HostListener('click', ['$event']) onMouseMiddleClick($event: Event) {
-    console.log($event);
+    this.log.debug(`Click. Event=${$event}`);
   }
   @HostListener('dblclick', ['$event']) onMouseDoubleClick($event: Event) {
     this.editorControl.closeFileHandler(this.fileContext);
   }
-  constructor(private editorControl: EditorControlService) { }
+  constructor(private editorControl: EditorControlService,
+              @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger) { }
 }
 
 /*

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
@@ -8,7 +8,7 @@
   
   Copyright Contributors to the Zowe Project.
 */
-import { Component, OnInit, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, OnInit, Input, OnChanges, SimpleChanges, Inject } from '@angular/core';
 import { listen, MessageConnection } from 'vscode-ws-jsonrpc/lib';
 import {
   BaseLanguageClient, CloseAction, ErrorAction,
@@ -17,6 +17,7 @@ import {
 import { MonacoService } from './monaco.service';
 import { EditorControlService } from '../../../shared/editor-control/editor-control.service';
 import { LanguageServerService } from '../../../shared/language-server/language-server.service';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 const ReconnectingWebSocket = require('reconnecting-websocket');
 
 @Component({
@@ -31,7 +32,8 @@ export class MonacoComponent implements OnInit, OnChanges {
   constructor(
     private monacoService: MonacoService,
     private editorControl: EditorControlService,
-    private languageService: LanguageServerService) {
+    private languageService: LanguageServerService,
+    @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger) {
   }
 
   ngOnInit() {
@@ -141,13 +143,13 @@ export class MonacoComponent implements OnInit, OnChanges {
         if (lang === language && connExist.indexOf(language) < 0) {
           this.listenTo(language);
         } else {
-          console.log(`${language} server already started!`);
+          this.log.warn(`${language} server already started!`);
         }
       } else {
         if (connExist.indexOf(language) < 0) {
           this.listenTo(language);
         } else {
-          console.log(`${language} server already started!`);
+          this.log.warn(`${language} server already started!`);
         }
       }
     }
@@ -174,7 +176,7 @@ export class MonacoComponent implements OnInit, OnChanges {
     const langWebSocket = this.createWebSocket(langUrl);
     const langService = createMonacoServices(this.editorControl.editor.getValue());
 
-    console.log(`Start listen to ${lang} server`);
+    this.log.info(`Connecting to ${lang} server`);
 
     listen({
       webSocket: langWebSocket,

--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -22,12 +22,9 @@ export class MonacoConfig {
     onMonacoLoad: this.onLoad.bind(this),
   };
 
-  constructor() { }
-
   onLoad() {
     let self = this;
     // here monaco object will be available as window.monaco use this function to extend monaco editor functionalities.
-    console.log((<any>window).monaco);
 
     monaco.languages.register({
       id: 'hlasm',

--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -8,7 +8,7 @@
   
   Copyright Contributors to the Zowe Project.
 */
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, Inject } from '@angular/core';
 import { Response } from '@angular/http';
 import { MatDialog } from '@angular/material';
 import { TreeNode, TREE_ACTIONS, TreeComponent } from 'angular-tree-component';
@@ -23,6 +23,7 @@ import { EditorService } from '../editor.service';
 import { UtilsService } from '../../shared/utils.service';
 import { DataAdapterService } from '../../shared/http/http.data.adapter.service';
 import { SnackBarService } from '../../shared/snack-bar.service';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 
 @Component({
   selector: 'app-project-tree',
@@ -85,7 +86,8 @@ export class ProjectTreeComponent implements OnInit {
     private dialog: MatDialog,
     private editorControl: EditorControlService,
     private snackBarService: SnackBarService,
-    private codeEditorService: EditorService) {
+    private codeEditorService: EditorService,
+    @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger) {
 
     this.editorControl.projectNode.subscribe((nodes) => {
       this.nodes = nodes;
@@ -113,7 +115,7 @@ export class ProjectTreeComponent implements OnInit {
     });
 
     this.editorControl.openDirectory.subscribe(dirName => {
-      console.log(dirName);
+      this.log.debug(`Open Dir=${dirName}`);
       if (dirName != null && dirName !== '') {
         if (dirName[0] == '/') {
           // start get project structure
@@ -177,7 +179,7 @@ export class ProjectTreeComponent implements OnInit {
     if (!$event.node.data.children && !$event.node.data.hasChildren) {
       const nodeData: ProjectStructure = $event.node.data;
       this.editorControl.openFile('', nodeData).subscribe(x => {
-        console.log('file loaded through project explorer.');
+        this.log.debug(`file loaded through project explorer.`);
       });
       // this.editorControl.openFileEmitter.emit(nodeData);
     }

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -8,7 +8,7 @@
 
   Copyright Contributors to the Zowe Project.
 */
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { ProjectContext } from '../model/project-context';
 import { ProjectStructure } from '../model/editor-project';
@@ -23,6 +23,7 @@ import { Observer } from 'rxjs/Observer';
 import { Http } from '@angular/http';
 import * as _ from 'lodash';
 import { MatDialog } from '@angular/material';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 
 export let EditorServiceInstance: BehaviorSubject<any> = new BehaviorSubject(undefined);
 /**
@@ -81,6 +82,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     private ngHttp: Http,
     private snackBar: SnackBarService,
     private dialog: MatDialog,
+    @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger
   ) {
     EditorServiceInstance.next(this);
   }
@@ -163,8 +165,8 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
       file.active = false;
     }
     if (fileContext) {
-      fileContext.opened ? console.warn(`File ${fileContext.name} already open.`) : fileContext.opened = true;
-      fileContext.active ? console.warn(`File ${fileContext.name} already active.`) : fileContext.active = true;
+      fileContext.opened ? this.log.warn(`File ${fileContext.name} already open.`) : fileContext.opened = true;
+      fileContext.active ? this.log.warn(`File ${fileContext.name} already active.`) : fileContext.active = true;
     }
     let currentOpenFileList = this._openFileList.getValue();
     currentOpenFileList.push(fileContext);
@@ -172,8 +174,8 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   }
 
   public closeFileHandler(fileContext: ProjectContext) {
-    !fileContext.opened ? console.warn(`File ${fileContext.name} already closed.`) : fileContext.opened = false;
-    !fileContext.active ? console.warn(`File ${fileContext.name} already inactive.`) : fileContext.active = false;
+    !fileContext.opened ? this.log.warn(`File ${fileContext.name} already closed.`) : fileContext.opened = false;
+    !fileContext.active ? this.log.warn(`File ${fileContext.name} already inactive.`) : fileContext.active = false;
     fileContext.changed = false;
     this._openFileList.next(this._openFileList.getValue().filter((file) => file.model.id !== fileContext.model.id));
   }

--- a/webClient/src/app/shared/http/http.data.adapter.service.ts
+++ b/webClient/src/app/shared/http/http.data.adapter.service.ts
@@ -8,13 +8,16 @@
   
   Copyright Contributors to the Zowe Project.
 */
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { ProjectDef } from '../model/project';
 import { ProjectStructure } from '../model/editor-project';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 import * as _ from 'lodash';
 
 @Injectable()
 export class DataAdapterService {
+
+  constructor(@Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger) {}
 
   convertProjectList(responseData: any): ProjectDef[] {
     return [{
@@ -44,7 +47,7 @@ export class DataAdapterService {
   }
 
   convertDatasetList(responseData: any): ProjectStructure[] {
-    console.log(responseData);
+    this.log.debug(`Dataset response=`,responseData);
     let entries = responseData.datasets;
     return entries.map((entry: any) => {
       let pds = entry.dsorg != null && entry.dsorg.isPDSDir;


### PR DESCRIPTION
Passing around the zowe named logger to components, directives, and services within the editor. This should hide a bit of debugging info that was spat out before.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>