### PR TITLE
app2app to open to files, folders, dslist

### DIFF
--- a/webClient/src/app/editor/code-editor/code-editor.component.html
+++ b/webClient/src/app/editor/code-editor/code-editor.component.html
@@ -14,7 +14,6 @@
     <p class="welcome">Welcome to the Zowe Editor!</p>
     <p>Please open a file from
       <span class="high-light">File Explorer</span> to start your journey!
-      <!--<br/> Save All Files [Ctrl + S]-->
     </p>
     <p></p>
   </div>

--- a/webClient/src/app/editor/code-editor/code-editor.component.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.component.ts
@@ -34,8 +34,7 @@ export class CodeEditorComponent implements OnInit {
     lightbulb: {
       enabled: true
     },
-    theme: 'vs-dark',
-    fontFamily: 'monaco'
+    theme: 'vs-dark'
   };
 
   public editorFile: { context: ProjectContext, reload: boolean, line?: number };

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
@@ -53,6 +53,7 @@ export class MonacoComponent implements OnInit, OnChanges {
   onMonacoInit(editor) {
     this.editorControl.editor.next(editor);
     this.keyBinds(editor);
+    /* disable for now...
     this.editorControl.connToLS.subscribe((lang) => {
       this.connectToLanguageServer(lang);
     });
@@ -61,6 +62,7 @@ export class MonacoComponent implements OnInit, OnChanges {
     });
 
     this.connectToLanguageServer();
+    */
   }
 
   keyBinds(editor: any) {

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -32,7 +32,9 @@ export let EditorServiceInstance: BehaviorSubject<any> = new BehaviorSubject(und
  * @export
  * @class EditorControlService
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuffer, ZLUX.IEditorSyntaxHighlighting {
   public createFileEmitter: EventEmitter<string> = new EventEmitter();
   public openProject: EventEmitter<string> = new EventEmitter();
@@ -634,6 +636,11 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
 
     this.openFileEmitter.emit(targetBuffer);
     return resultOpenObs;
+  }
+
+  loadDirectory(path: string) {
+    this.log.debug('Loading directory=',path);
+    this.openDirectory.next(path);
   }
   /**
      * Save a buffer into a file.


### PR DESCRIPTION
Implements app2app listener for opening up to a directory, DS listing, or a file.
Fixed a bug along the way too, where a file window would be open but empty due to a timing issue where an exception got thrown. It wasn't subscribing to an event properly.
Also removed the use of the monaco font... it was failing to load, making for an ugly font fallback.
Also disabled unused LSP websocket. Can reenable when we start making use of it.