### PR TITLE
Small tweak to default configuration for slight performance boost

### DIFF
--- a/webClient/src/app/editor/code-editor/code-editor.component.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.component.ts
@@ -29,11 +29,19 @@ export class CodeEditorComponent implements OnInit {
   private openFileList: ProjectContext[];
   private noOpenFile: boolean;
 
+  //TODO load from configservice
   public options = {
     glyphMargin: true,
     lightbulb: {
       enabled: true
     },
+    codeLense: true,
+    iconsInSuggestions: true,
+    minimap: {
+      enabled: false
+    },
+    suggestOnTriggerCharacters: true,
+    quickSuggestions: true,
     theme: 'vs-dark'
   };
 
@@ -82,6 +90,7 @@ export class CodeEditorComponent implements OnInit {
     }
   }
 
+  //TODO this is causing the error of nothing showing up when a tab is closed
   closeFile(fileContext: ProjectContext) {
     this.editorFile = undefined;
     this.codeEditorService.closeFile(fileContext);


### PR DESCRIPTION
Implicit values are now more explicit: everything here was true before except that minimap has been turned off due to its use of canvas having a slight performance impact versus how often people use such a thing.
We'll make this end-user configurable soon.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>