### PR TITLE
Resize editor on viewport resize

### DIFF
--- a/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.ts
+++ b/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.ts
@@ -8,10 +8,12 @@
   
   Copyright Contributors to the Zowe Project.
 */
-import { Component, OnInit, Input, Output, EventEmitter, Directive, HostListener, Inject } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter,
+         Directive, HostListener, Inject, ViewChild } from '@angular/core';
 import { ProjectContext } from '../../../shared/model/project-context';
 import { EditorControlService } from '../../../shared/editor-control/editor-control.service';
-import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
+import { Angular2InjectionTokens, Angular2PluginViewportEvents } from 'pluginlib/inject-resources';
+import { PerfectScrollbarComponent } from 'ngx-perfect-scrollbar';
 
 @Component({
   selector: 'app-file-tabs',
@@ -23,14 +25,18 @@ export class FileTabsComponent implements OnInit {
   @Input() data: ProjectContext[];
   @Output() remove = new EventEmitter<ProjectContext>();
   @Output() select = new EventEmitter<ProjectContext>();
+  @ViewChild(PerfectScrollbarComponent) componentRef: PerfectScrollbarComponent;
 
   private scrollConfig = {
     wheelPropagation: true,
   };
 
-  constructor() { }
+  constructor(@Inject(Angular2InjectionTokens.VIEWPORT_EVENTS) private viewportEvents: Angular2PluginViewportEvents) { }
 
   ngOnInit() {
+    this.viewportEvents.resized.subscribe(()=> {
+      this.componentRef.directiveRef.update();
+    });
   }
 
   clickHandler(e: Event, item: ProjectContext) {

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
@@ -17,7 +17,7 @@ import {
 import { MonacoService } from './monaco.service';
 import { EditorControlService } from '../../../shared/editor-control/editor-control.service';
 import { LanguageServerService } from '../../../shared/language-server/language-server.service';
-import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
+import { Angular2InjectionTokens, Angular2PluginViewportEvents } from 'pluginlib/inject-resources';
 const ReconnectingWebSocket = require('reconnecting-websocket');
 
 @Component({
@@ -33,10 +33,12 @@ export class MonacoComponent implements OnInit, OnChanges {
     private monacoService: MonacoService,
     private editorControl: EditorControlService,
     private languageService: LanguageServerService,
-    @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger) {
+    @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger,
+    @Inject(Angular2InjectionTokens.VIEWPORT_EVENTS) private viewportEvents: Angular2PluginViewportEvents) {
   }
 
   ngOnInit() {
+
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -53,7 +55,10 @@ export class MonacoComponent implements OnInit, OnChanges {
   onMonacoInit(editor) {
     this.editorControl.editor.next(editor);
     this.keyBinds(editor);
-    /* disable for now...
+    this.viewportEvents.resized.subscribe(()=> {
+      editor.layout()
+    });
+      /* disable for now...
     this.editorControl.connToLS.subscribe((lang) => {
       this.connectToLanguageServer(lang);
     });


### PR DESCRIPTION
Two elements (tab bar and editor) have functions for being called when parent elements are resized. This makes resizing more correct but it doesn't solve all issues yet.
Somehow, the editor area (as opposed to the file tree area) ends up expanding fine, but not shrinking. Not sure what causes it at this time, but this isnt a regression.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>