### PR TITLE
added notifications for failure to open file in editor

### DIFF
--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -8,7 +8,8 @@
   
   Copyright Contributors to the Zowe Project.
 */
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 import { HttpService } from '../../../shared/http/http.service';
 import { ProjectStructure } from '../../../shared/model/editor-project';
 import { ProjectContext } from '../../../shared/model/project-context';
@@ -31,6 +32,7 @@ export class MonacoService {
   private decorations: string[] = [];
   
   constructor(
+    @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger,
     private httpService: HttpService,
     private http: Http,
     private dataAdapter: DataAdapterService,
@@ -115,10 +117,12 @@ export class MonacoService {
               }
             },
             error: (err) => {
+              this.log.warn(err);
             }
           });
         },
         error: (err) => {
+          this.log.warn(`${fileNode.name} could not be opened`);
           if (err.status === 403) {
             this.snackBar.open(`${fileNode.name} could not be opened due to permissions`,
               'Close', { duration: MessageDuration.Short, panelClass: 'center' });


### PR DESCRIPTION
Added a snackbar that notifies the user if they don't have permissions to open a file or if the file they tried to access no longer exists. Otherwise gives a generic message about not being able to open the file.

Signed-off-by: Reet Chowdhary <rchowdhary@rocketsoftware.com>