### PR TITLE
Editor/dataset switching ui

### DIFF
--- a/webClient/src/app/editor/frame/frame.component.scss
+++ b/webClient/src/app/editor/frame/frame.component.scss
@@ -64,8 +64,8 @@
       flex: 0 0 230px;
       .section-container {
         min-width: 315px;
-        padding-top: 36px;
-        overflow-y: auto;
+        padding-top: 0px;
+        overflow-y: hidden;
         overflow-x: hidden;
         display: none;
         &.active {

--- a/webClient/src/app/editor/project-tree/project-tree.component.html
+++ b/webClient/src/app/editor/project-tree/project-tree.component.html
@@ -14,7 +14,7 @@
   <button mat-raised-button class="button-open" color="primary" (click)="openDirectory()">Open Directory</button>
 </div>
 -->
-<div class="explorer-container">
+<div class="file-explorer-container">
   <zlux-file-explorer #fileExplorer
   (nodeClick)="onNodeClick($event)"
   (newFileClick)="onNewFileClick($event)"
@@ -24,14 +24,14 @@
   (datasetSelect)="onDatasetSelect()"
   (ussSelect)="onUssSelect()"
   (pathChanged)="onPathChanged($event)"
-  [style]="{'height': '630px', 'overflow-y': 'auto'}"
+  [style]="{'height': '100%', 'padding-bottom': '100px'}"
   >
   </zlux-file-explorer>
 </div>
 <!-- The below "dataset-container" will eventually be truncated as Dataset viewing capability 
 improves in the File Explorer. Keeping this structure here in the mean time for datasets. -->
 <div class="dataset-container" *ngIf="showDatasets">
-  <perfect-scrollbar [config]="scrollConfig" [disabled]="false">
+  <perfect-scrollbar [config]="scrollConfig" [disabled]="false" style="height: calc(100% - 45px);">
     <tree-root #tree [nodes]="nodes" [options]="options" (activate)="nodeActivate($event)" (loadNodeChildren)="treeUpdate($event)">
       <ng-template #treeNodeWrapperTemplate let-node let-index="index">
         <div class="node-wrapper" [style.padding-left]="node.getNodePadding()">

--- a/webClient/src/app/editor/project-tree/project-tree.component.html
+++ b/webClient/src/app/editor/project-tree/project-tree.component.html
@@ -24,6 +24,7 @@
   (datasetSelect)="onDatasetSelect()"
   (ussSelect)="onUssSelect()"
   (pathChanged)="onPathChanged($event)"
+  [style]="{'height': '630px', 'overflow-y': 'auto'}"
   >
   </zlux-file-explorer>
 </div>

--- a/webClient/src/app/editor/project-tree/project-tree.component.scss
+++ b/webClient/src/app/editor/project-tree/project-tree.component.scss
@@ -174,16 +174,16 @@
     }
   }
   
-  .explorer-container {
+  .file-explorer-container {
     margin-left: -5px;
     margin-top: 5px;
-    //padding-bottom: 100px;
+    height: 100%;
   }
 
   .dataset-container { //Note: This is temporary and will be removed when Dataset functionality for Explorer gets better.
     padding-left: 10px;
     padding-top: 10px;
-    height: 630px;
+    height: 100%;
   }
 }
 

--- a/webClient/src/app/editor/project-tree/project-tree.component.scss
+++ b/webClient/src/app/editor/project-tree/project-tree.component.scss
@@ -183,6 +183,7 @@
   .dataset-container { //Note: This is temporary and will be removed when Dataset functionality for Explorer gets better.
     padding-left: 10px;
     padding-top: 10px;
+    height: 630px;
   }
 }
 

--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -178,6 +178,10 @@ export class ProjectTreeComponent implements OnInit {
   onDatasetSelect() {
     this.fileExplorer.hideExplorers();
     this.showDatasets = true;
+    // This is a pseudo-hacky way of styling the explorer that hides the unfinished dataset
+    // browser to use the original Editor one. This can be removed once Explorer datasets are used.
+    let myElement = document.getElementsByClassName("file-explorer-container")[0];
+    myElement.setAttribute("style", "height: 75px;");
   }
 
   onDeleteClick($event: any){
@@ -228,6 +232,9 @@ export class ProjectTreeComponent implements OnInit {
   onUssSelect() {
     this.fileExplorer.showUss();
     this.showDatasets = false;
+    // This is a pseudo-hacky way of styling that pops back the Explorer.
+    let myElement = document.getElementsByClassName("file-explorer-container")[0];
+    myElement.setAttribute("style", "height: 100%;");
   }
 
   openProject() {

--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -146,12 +146,13 @@ export class ProjectTreeComponent implements OnInit {
         } else { //Datasets
           //Note: This temporary hack is used to show datasets using the original slower Editor structure.
           // Will be removed when Dataset functionality for Explorer gets better.
-            this.fileExplorer.hideExplorers();
-            this.showDatasets = true;
 
           let requestUrl = ZoweZLUX.uriBroker.datasetMetadataUri(dirName, 'true');
           this.httpService.get(requestUrl)
             .subscribe((response: any) => {
+              this.fileExplorer.showDatasets();
+              this.fileExplorer.hideExplorers();
+              this.showDatasets = true;
               this.nodes = this.dataAdapter.convertDatasetList(response);
               this.editorControl.setProjectNode(this.nodes);
               this.editorControl.initProjectContext(dirName, this.nodes);

--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -130,9 +130,8 @@ export class ProjectTreeComponent implements OnInit {
     this.editorControl.openDirectory.subscribe(dirName => {
       //Note: This temporary hack is used to hide datasets using the original slower Editor structure.
       // Will be removed when Dataset functionality for Explorer gets better.
-        this.fileExplorer.showUss();
+        this.onUssSelect();
         this.fileExplorer.updateDirectory(dirName);
-        this.showDatasets = false;
     });
 
     this.editorControl.openDataset.subscribe(dirName => {
@@ -140,9 +139,8 @@ export class ProjectTreeComponent implements OnInit {
         if (dirName[0] == '/') {
           //Note: This temporary hack is used to hide datasets using the original slower Editor structure.
           // Will be removed when Dataset functionality for Explorer gets better.
-            this.fileExplorer.showUss();
+            this.onUssSelect();
             this.fileExplorer.updateDirectory(dirName);
-            this.showDatasets = false;
         } else { //Datasets
           //Note: This temporary hack is used to show datasets using the original slower Editor structure.
           // Will be removed when Dataset functionality for Explorer gets better.
@@ -151,8 +149,7 @@ export class ProjectTreeComponent implements OnInit {
           this.httpService.get(requestUrl)
             .subscribe((response: any) => {
               this.fileExplorer.showDatasets();
-              this.fileExplorer.hideExplorers();
-              this.showDatasets = true;
+              this.onDatasetSelect();
               this.nodes = this.dataAdapter.convertDatasetList(response);
               this.editorControl.setProjectNode(this.nodes);
               this.editorControl.initProjectContext(dirName, this.nodes);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20528015/58448215-2e9de580-80d5-11e9-8c38-c3934e537eb9.png)

Makes it so that the tabs are always visible (and don't get hidden with large amounts of data present so the user doesn't have to scroll back up)

Also, fixed a bug where going into Dataset view from the top left option menu did not correctly activate the Dataset tab.

**PART 1 of 2** https://github.com/zowe/zlux-file-explorer/pull/14