### PR TITLE
Set suppressScrollY to true for perfect scroll file tabs component

### DIFF
--- a/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.ts
+++ b/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.ts
@@ -29,6 +29,7 @@ export class FileTabsComponent implements OnInit {
 
   private scrollConfig = {
     wheelPropagation: true,
+    suppressScrollY: true,
   };
 
   constructor(@Inject(Angular2InjectionTokens.VIEWPORT_EVENTS) private viewportEvents: Angular2PluginViewportEvents) { }


### PR DESCRIPTION
Fix editor file tab behaviour that allows for undesired vertical scrolling

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>