### PR TITLE
[MVD-2438] Fix for file tab display issues in Chrome

### DIFF
--- a/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.html
+++ b/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.html
@@ -12,7 +12,7 @@
   <div class="tabs-container">
     <ul class="tabs-file-list">
       <li mClick class="tabs-file" [fileContext]="item" [ngClass]="{'active':item.active}" *ngFor="let item of data" (click)="clickHandler($event, item)">
-        {{item.name}}
+        <span class="filename">{{item.name}}</span>
         <mat-icon class="close-file" (click)="remove.next(item)">clear</mat-icon>
         <mat-icon *ngIf="item.changed" class="changed-file">fiber_manual_record</mat-icon>
       </li>

--- a/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.html
+++ b/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.html
@@ -8,7 +8,7 @@
   
   Copyright Contributors to the Zowe Project.
 -->
-<perfect-scrollbar [config]="scrollConfig" [disabled]="false">
+<perfect-scrollbar [config]="fileTabsScrollConfig" [disabled]="false">
   <div class="tabs-container">
     <ul class="tabs-file-list">
       <li mClick class="tabs-file" [fileContext]="item" [ngClass]="{'active':item.active}" *ngFor="let item of data" (click)="clickHandler($event, item)">

--- a/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.scss
+++ b/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.scss
@@ -11,30 +11,42 @@
 :host {
   display: block;
   margin-top: -32px;
+  height: 32px;
+  max-height: 32px;
   .tabs-container {
-    height: 32px;
     width: 100%;
+    max-height: 32px;
     background-color: #303030;
     .tabs-file-list {
       list-style-type: none;
       display: flex;
-      justify-content: start;
+      justify-content: flex-start;
+      margin-bottom: 0;
       height: 100%;
       .tabs-file {
         display: inline-block;
         flex-shrink: 0;
         flex-basis: 150px;
         line-height: 22px;
+        max-height: 32px;
         padding: 5px 10px;
         color: #e0e0e0;
         border-right: 1px solid #212121;
+        white-space: nowrap;
+        text-align: left;
         cursor: pointer;
+        .filename{
+          width: 100px;
+          text-overflow: ellipsis;
+          overflow: hidden;
+          float: left;
+        }
         &.active {
           border-bottom: 3px solid #3f51b5;
         }
         .changed-file {
           text-align: center;
-          line-height: 24px;
+          line-height: 32px;
           font-size: 12px;
           float: right;
           width: 12px;
@@ -43,7 +55,7 @@
         }
         .close-file {
           text-align: right;
-          line-height: 24px;
+          line-height: 22px;
           font-size: 16px;
           float: right;
         }

--- a/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.ts
+++ b/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.ts
@@ -31,6 +31,13 @@ export class FileTabsComponent implements OnInit {
     wheelPropagation: true,
   };
 
+  private fileTabsScrollConfig = {
+    wheelPropagation: true,
+    suppressScrollY: true,
+    suppressScrollX: false,
+    useBothWheelAxes: true
+  };
+
   constructor(@Inject(Angular2InjectionTokens.VIEWPORT_EVENTS) private viewportEvents: Angular2PluginViewportEvents) { }
 
   ngOnInit() {

--- a/webClient/src/app/editor/frame/frame.component.scss
+++ b/webClient/src/app/editor/frame/frame.component.scss
@@ -162,7 +162,7 @@
       }
     }
     .gz-editor {
-      // width: 100%;
+      width: 600px;
       height: 100%;
       position: relative;
       flex: 1 0 auto;

--- a/webClient/src/app/editor/frame/frame.component.scss
+++ b/webClient/src/app/editor/frame/frame.component.scss
@@ -162,10 +162,10 @@
       }
     }
     .gz-editor {
-      width: 600px;
       height: 100%;
       position: relative;
-      flex: 1 0 auto;
+      flex: 1 1 auto;
+      overflow: hidden;
     }
   }
 }


### PR DESCRIPTION
Previously in Chrome, filenames would wrap onto a new line creating an additional vertical scroll bar in the file tab display.  Additionally, the filename would wrap the close button below the tab which gives the appearance of a missing close button.  Both issues have been mitigated by wrapping the filename within a span and setting a maximum width for the text.  To ensure the scroll bar does not reappear, the bottom margin in the tabs-file-list class has been set to 0px.

<img width="775" alt="2019_01_11_11_53_48_Zowe_Desktop_File_interface" src="https://user-images.githubusercontent.com/7998484/59777678-1740bb00-9283-11e9-9f94-50257e18b14b.png">

![Fixed](https://user-images.githubusercontent.com/7998484/59777707-2162b980-9283-11e9-9936-718a8f3af962.png)


Opening many tabs past the current width of the window also created an additional horizontal scroll bar for the body of the app.  This issue has been mitigated by setting a width for the gz-editor class.
