### PR TITLE
[MVD-2967] No language menu for new files

### DIFF
--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -407,6 +407,8 @@ export class MenuBarComponent implements OnInit {
 
   createFile() {
     this.editorControl.createFile("(new)");
+    let fileContext = this.editorControl.fetchActiveFile();
+    this.editorControl.initializedFile.next(fileContext);
     /*
     let newFileRef = this.dialog.open(NewFileComponent, {
       width: '500px'


### PR DESCRIPTION
File context for a new file is fetched upon creation and pushed to the initializedFile EventEmitter, fixing the issue where the language menu would not appear.

![image](https://user-images.githubusercontent.com/7998484/59868463-f483d480-935e-11e9-9130-679d20a0d298.png)

![image](https://user-images.githubusercontent.com/7998484/59868449-ee8df380-935e-11e9-9132-9deafd172efd.png)
