### PR TITLE
Tooltips for tabs to display file names that exceed tab width

### DIFF
--- a/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.html
+++ b/webClient/src/app/editor/code-editor/file-tabs/file-tabs.component.html
@@ -11,7 +11,7 @@
 <perfect-scrollbar [config]="fileTabsScrollConfig" [disabled]="false">
   <div class="tabs-container">
     <ul class="tabs-file-list">
-      <li mClick class="tabs-file" [fileContext]="item" [ngClass]="{'active':item.active}" *ngFor="let item of data" (click)="clickHandler($event, item)">
+      <li mClick class="tabs-file" [fileContext]="item" [ngClass]="{'active':item.active}" *ngFor="let item of data" (click)="clickHandler($event, item)" title="{{item.name}}">
         <span class="filename">{{item.name}}</span>
         <mat-icon class="close-file" (click)="remove.next(item)">clear</mat-icon>
         <mat-icon *ngIf="item.changed" class="changed-file">fiber_manual_record</mat-icon>


### PR DESCRIPTION
Added tool tip to each tab so that files whose name exceeds the width of the tab may be viewed.
![image](https://user-images.githubusercontent.com/7998484/60040556-4c844900-9687-11e9-84d2-77afb752e379.png)
