### PR TITLE
Language Server 'enable' toggle not working

### DIFF
--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -442,7 +442,7 @@ export class MenuBarComponent implements OnInit {
 
     newFileRef.afterClosed().subscribe(result => {
       if (result) {
-        this.languageServer.updateSettings(JSON.parse(result.config));
+        this.languageServer.updateSettings(result);
         if (result.enable) {
           this.editorControl.connToLS.next();
         } else {

--- a/webClient/src/app/shared/dialog/language-server/language-server.component.ts
+++ b/webClient/src/app/shared/dialog/language-server/language-server.component.ts
@@ -24,7 +24,7 @@ export class LanguageServerComponent implements OnInit {
 
   constructor(private languageServer: LanguageServerService) {
     this.settings.config = JSON.stringify(this.languageServer.getSettings());
-    this.settings.enable = true;
+    this.settings.enable = this.languageServer.getEnabled();
   }
 
   ngOnInit() {

--- a/webClient/src/app/shared/language-server/language-server.service.ts
+++ b/webClient/src/app/shared/language-server/language-server.service.ts
@@ -16,6 +16,7 @@ export class LanguageServerService {
 
   config = { domain: 'ws://localhost:3000', endpoint: { hlasm: 'asmServer', json: 'jsonServer' } };
   connections: { name: string, connection: MessageConnection }[] = [];
+  enabled: boolean = true;
 
   constructor() { }
 
@@ -23,8 +24,13 @@ export class LanguageServerService {
     return this.config;
   }
 
-  updateSettings(config: any) {
-    this.config = config;
+  getEnabled(): boolean {
+    return this.enabled;
+  }
+
+  updateSettings(result: any) {
+    this.config = JSON.parse(result.config);
+    this.enabled = result.enable;
   }
 
   getLanguageUrl(lang: string): string {

--- a/webClient/src/app/shared/language-server/language-server.service.ts
+++ b/webClient/src/app/shared/language-server/language-server.service.ts
@@ -8,8 +8,9 @@
   
   Copyright Contributors to the Zowe Project.
 */
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { MessageConnection } from 'vscode-jsonrpc';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 
 @Injectable()
 export class LanguageServerService {
@@ -18,7 +19,7 @@ export class LanguageServerService {
   connections: { name: string, connection: MessageConnection }[] = [];
   enabled: boolean = true;
 
-  constructor() { }
+  constructor(@Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger) { }
 
   getSettings(): any {
     return this.config;
@@ -28,9 +29,19 @@ export class LanguageServerService {
     return this.enabled;
   }
 
-  updateSettings(result: any) {
-    this.config = JSON.parse(result.config);
-    this.enabled = result.enable;
+  updateSettings(langSettings: any) {
+    if(langSettings === undefined){
+      this.log.debug("Settings are invalid (undefined)");
+    } else {
+      try{
+        var serverConfig = JSON.parse(langSettings.config);
+        this.config = serverConfig;
+        this.enabled = langSettings.enable;
+      }catch(e){
+        this.log.debug(e);
+        console.log(e);
+      }
+    }
   }
 
   getLanguageUrl(lang: string): string {


### PR DESCRIPTION
The language server dialog pertains an enable button which was previously unimplemented.  Only the config was saved.  Added functionality to updateSettings() in language-server service.