### PR TITLE
Save and restore cursor and view between tabs

### DIFF
--- a/webClient/src/app/editor/code-editor/code-editor.component.html
+++ b/webClient/src/app/editor/code-editor/code-editor.component.html
@@ -8,12 +8,11 @@
   
   Copyright Contributors to the Zowe Project.
 -->
-<div class="editor-instruction" [ngClass]="{'hide': !noOpenFile}">
+<div class="editor-instruction" *ngIf="noOpenFile">
   <div class="instruction">
     <!-- <img src="./assets/logo.svg" alt="logo"> -->
     <p class="welcome">Welcome to the <span class="welcome" style="color: #4286f4">Zowe</span> Editor.</p>
     <p>Use the explorer on the left-hand side to start your journey! <!-- Technically not just a file explorer, since it displays datasets too. -->
-      <!--<br/> Save All Files [Ctrl + S]--> 
     </p>
   </div>
 </div>

--- a/webClient/src/app/editor/code-editor/code-editor.component.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.component.ts
@@ -25,7 +25,6 @@ import { CodeEditorService } from './code-editor.service';
   styleUrls: ['./code-editor.component.scss']
 })
 export class CodeEditorComponent implements OnInit {
-
   private openFileList: ProjectContext[];
   private noOpenFile: boolean;
 
@@ -52,6 +51,7 @@ export class CodeEditorComponent implements OnInit {
     private monacoService: MonacoService,
     private editorService: EditorService,
     private codeEditorService: CodeEditorService) {
+    //respond to the request to open
     this.editorControl.openFileEmitter.subscribe((fileNode: ProjectStructure) => {
       this.openFile(fileNode);
     });
@@ -106,9 +106,14 @@ export class CodeEditorComponent implements OnInit {
     this.codeEditorService.closeFile(fileContext);
   }
 
+  /* 
+     this.editorFile instructs monaco to change, 
+     which in turn invokes monacoservice.openfile, 
+     which kicks off discovery involving the editor controller   
+  */
   selectFile(fileContext: ProjectContext, broadcast: boolean, line?: number) {
-    this.editorFile = { context: fileContext, reload: false, line: line };
     this.codeEditorService.selectFile(fileContext, broadcast);
+    this.editorFile = { context: fileContext, reload: false, line: line };
   }
 }
 

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -69,7 +69,9 @@ export class MonacoService {
      From the controller to say whether this is new, or just a selection change
    */
   openFile(fileNode: ProjectContext, reload: boolean, line?: number) {
+    this.editorControl.saveCursorState();
     if (fileNode.temp) {
+      //blank new file
       this.setMonacoModel(fileNode, <{ contents: string, language: string }>{ contents: '', language: '' }).subscribe(() => {
         this.editorControl.fileOpened.next({ buffer: fileNode, file: fileNode.name });
         if (line) {
@@ -101,6 +103,7 @@ export class MonacoService {
       }
       _observable.subscribe({
         next: (response: any) => {
+          //network load or switched to currently open file
           const resJson = response;
           this.setMonacoModel(fileNode, <{ contents: string, language: string }>resJson).subscribe({
             next: () => {


### PR DESCRIPTION
Cache and restore cursor and view information per opened file upon selection change
This utilizes monaco's ability to get and set states for the cursor, selection, and view - so we're giving monaco all the info that it expects upon changing the view between multiple files.
Basically, before when selecting tabs in the editor, each tab would get the cursor reset to position 0,0 and any text would be deselected. Now, the position & selection is all preserved while the file remains open. Upon closing the file this information is purged.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>