### PR TITLE
Adjusted JCL blue coloring to match ISPF

### DIFF
--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -213,7 +213,7 @@ export const JCL_DARK: Theme = {
     { token: 'jcl-variable', foreground: '50eb24' }, // Green
     { token: 'jcl-invalid', foreground: 'ffadc7', background: 'ff8173', fontStyle: 'bold' }, // Light red, background is supposed to be "highlight" 
     //of text but it doesn't seem to work?
-    { token: 'jcl-none', foreground: '815aff' }, // Blue-Purple
+    { token: 'jcl-none', foreground: '75abff' }, // Blue
     { token: 'jcl-default', foreground: '50eb24' }, // Green
 	]
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/20528015/61491608-92c68280-a97d-11e9-8687-22ffb503d3f9.png)

-->

![image](https://user-images.githubusercontent.com/20528015/61491622-9c4fea80-a97d-11e9-897b-0707de906681.png)

Very tiny fix but this was bothering me an unholy amount.

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>