### PR TITLE
Bugfix for menu positioning

### DIFF
--- a/webClient/src/app/core/menu-bar/menu-bar.component.scss
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.scss
@@ -8,6 +8,8 @@
   
   Copyright Contributors to the Zowe Project.
 */
+$line-height: 32px;
+
 :host {
   .gz-menu-bar {
     background-color: #303030;
@@ -24,7 +26,7 @@
       .gz-menu-section {
         position: relative;
         font-size: 14px;
-        line-height: 32px;
+        line-height: $line-height;
         background-color: #303030;
         padding: 0 10px;
         list-style: none;
@@ -65,6 +67,7 @@
           display: initial;
           position: absolute;
           left: 0;
+          top: $line-height;
           max-height: calc(90% - 45px);
           overflow-y: auto;
         }


### PR DESCRIPTION
Made the menu offset explicit rather than implicit, which had different behavior on webkit versus non webkit browsers.
Webkit: lack of "top" determined that the previous element's height should be the offset
Firefox, edge: lack of "top" meant 0px


Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>