### PR TITLE
Add ability to build as a conda package

### DIFF
--- a/build/bld.bat
+++ b/build/bld.bat
@@ -1,0 +1,67 @@
+@echo off
+REM This program and the accompanying materials are
+REM made available under the terms of the Eclipse Public License v2.0 which accompanies
+REM this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+REM 
+REM SPDX-License-Identifier: EPL-2.0
+REM 
+REM Copyright Contributors to the Zowe Project.
+
+set NODE_PATH=.;.\node_modules
+cd %SRC_DIR%
+mkdir %SRC_DIR%\..\zlux-app-manager
+robocopy %PREFIX%\lib\zowe\zlux\zlux-app-manager %SRC_DIR%\..\zlux-app-manager /E > nul
+mkdir %SRC_DIR%\..\zlux-platform
+robocopy %PREFIX%\lib\zowe\zlux\zlux-platform %SRC_DIR%\..\zlux-app-manager /E > nul
+
+REM absolute nonsense to work around windows utility path limitations.
+REM rd and del have issues with long paths
+if not exist %SRC_DIR%\temp_nonsense mkdir %SRC_DIR%\temp_nonsense
+
+if exist "nodeServer" (
+  cd nodeServer
+  CALL npm install
+  CALL npm run build
+  cd ..
+  robocopy %SRC_DIR%\temp_nonsense %SRC_DIR%\nodeServer /purge > nul
+  rmdir %SRC_DIR%\nodeServer
+)
+if exist "webClient" (
+  cd webClient
+  CALL npm install
+  setlocal
+  set MVD_DESKTOP_DIR=%SRC_DIR%\zlux-app-manager\virtual-desktop
+  CALL npm run build
+  CALL npm run i18n
+  cd ..
+  robocopy %SRC_DIR%\temp_nonsense %SRC_DIR%\webClient /purge > nul
+  rmdir %SRC_DIR%\webClient
+  endlocal
+)
+
+if exist ".git" (
+  robocopy %SRC_DIR%\temp_nonsense %SRC_DIR%\.git /purge > nul
+  rmdir %SRC_DIR%\.git
+)
+
+robocopy %SRC_DIR%\temp_nonsense %SRC_DIR%\build /purge > nul
+rmdir build
+del /F /S /Q "sonar-project.properties"
+del /F /S /Q *.ppf
+del /F /S /Q .gitignore .gitattributes .gitmodules
+del /F /S /Q .npm*
+del /F /S /Q Jenkinsfile
+del /F /S /Q settings.gradle
+rd /S /Q __pycache__
+
+del /F /S /Q build_env_setup.bat  conda_build.bat  metadata_conda_debug.yaml setup.py
+
+if not exist %PREFIX%/lib/zowe/zlux/zlux-app-server/defaults/plugins mkdir %PREFIX%/lib/zowe/zlux/zlux-app-server/defaults/plugins
+echo '{"identifier":"%PKG_NAME%","pluginLocation":"%PREFIX%/lib/zowe/apps/%PKG_NAME%/%PKG_VERSION%"}' ^
+     > %PREFIX%/lib/zowe/zlux/zlux-app-server/defaults/plugins/%PKG_NAME%.json
+
+if not exist %PREFIX%\lib\zowe\apps\%PKG_NAME%\%PKG_VERSION% mkdir %PREFIX%\lib\zowe\apps\%PKG_NAME%\%PKG_VERSION%
+robocopy %SRC_DIR% %PREFIX%\lib\zowe\apps\%PKG_NAME%\%PKG_VERSION% * /E > nul
+rd /S /Q %SRC_DIR%\temp_nonsense
+exit 0
+

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+export NODE_PATH=.:./node_modules
+cd ${SRC_DIR}
+cp -r ${PREFIX}/lib/zowe/zlux/zlux-app-manager ../
+cp -r ${PREFIX}/lib/zowe/zlux/zlux-platform ../
+if [ -d "./nodeServer" ]
+then
+    cd nodeServer
+    npm install
+    npm run build
+    cd ..
+fi
+
+if [ -d "./webClient" ]
+then
+    cd webClient
+    npm install
+    MVD_DESKTOP_DIR=${PREFIX}/lib/zowe/zlux/zlux-app-manager/virtual-desktop npm run build
+    MVD_DESKTOP_DIR=${PREFIX}/lib/zowe/zlux/zlux-app-manager/virtual-desktop npm run i18n && 0
+    cd ..
+fi
+
+rm -rf webClient nodeServer dco-signoffs
+rm -rf .git* */.git* */*/.git* */*/*/.git*
+rm -rf .editor* .angular*
+rm -f sonar-project.properties
+rm -rf ../zlux-app-manager
+rm -rf ../zlux-platform
+mkdir -p $PREFIX/lib/zowe/apps/$PKG_NAME/$PKG_VERSION
+cp -r . $PREFIX/lib/zowe/apps/$PKG_NAME/$PKG_VERSION
+cd $PREFIX/lib/zowe/apps/$PKG_NAME/$PKG_VERSION
+rm -rf __pycache__  build_env_setup.sh  conda_build.sh  metadata_conda_debug.yaml setup.py build
+mkdir -p $PREFIX/lib/zowe/zlux/zlux-app-server/defaults/plugins
+echo "{\"identifier\":\"${PKG_NAME}\",\"pluginLocation\":\"${PREFIX}/lib/zowe/apps/${PKG_NAME}/${PKG_VERSION}\"}" \
+     > $PREFIX/lib/zowe/zlux/zlux-app-server/defaults/plugins/${PKG_NAME}.json
+exit 0
+

--- a/build/meta.yaml
+++ b/build/meta.yaml
@@ -1,0 +1,41 @@
+{% set data = load_setup_py_data(setup_file='../setup.py', from_recipe_dir=True) %}
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+package:
+  name: "{{ data.get('name')|lower }}"
+  version: "{{ data.get('version') }}"
+
+source:
+  path: ../
+
+build:
+  number: 0
+  string: "zowe"
+#  noarch: generic
+#  features:
+#    - zowe
+
+requirements:
+  build:
+    - python >=3
+    - setuptools
+    - nodejs >=6.14.0,<9.0.0
+    - zowe-ui >=1.6.0
+  run:
+    {{ data.get('uiVersion') }}
+
+about:
+  home: "https://zowe.org"
+  license: "data.get('license')"
+  license_family: "OTHER"
+  license_file: "LICENSE"
+  summary: "{{ data.get('description') }}"
+  doc_url: "https://docs.zowe.org"
+  dev_url: "{{ data.get('homepage') }}"

--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -3,6 +3,9 @@
   "apiVersion": "1.0.0",
   "pluginVersion": "2.1.0",
   "pluginType": "application",
+  "author": "Zowe",
+  "license": "EPL-2.0",
+  "homepage": "https://github.com/zowe/zlux-editor",
   "webContent": {
     "framework": "angular",
     "launchDefinition": {

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,45 @@
+from distutils.core import setup
+import json
+import os
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+print('Loading package attributes from pluginDefinition.json')
+with open('pluginDefinition.json', 'r') as f:
+  pluginDef = json.load(f)
+  if ('license' in pluginDef):
+      license = pluginDef['license']
+  else:
+      license = "UNKNOWN"
+
+  if ('webContent' in pluginDef):
+      if ('descriptionDefault' in pluginDef['webContent']):
+          description=pluginDef['webContent']['descriptionDefault']
+      else:
+          description=""
+  else:
+      description=""
+
+  if ('homepage' in pluginDef):
+    homepage=pluginDef['homepage']
+  else:
+    homepage=""
+
+  if ('descriptionDefault' in pluginDef):
+      description = pluginDef['descriptionDefault']
+
+  uiVersion=os.getenv('ZLUX_NEEDED', '#zowe-ui prereq outside of conda')
+  if (uiVersion != '#zowe-ui prereq outside of conda'):
+    uiVersion=f"- zowe-ui {uiVersion}"
+    
+  setup(name=pluginDef['identifier'],
+        version=pluginDef['pluginVersion'],
+        description=description,
+        license=license,
+        homepage=homepage,
+        uiVersion=uiVersion )


### PR DESCRIPTION
Adds scripting that is useful for plugins to be conda packages.
This SHOULD work for all plugins that are zowe conformant.
More PRs to come for each app, unfortunately.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>