### PR TITLE
Fix node-sass dep. version issue with node 12

### DIFF
--- a/webClient/package.json
+++ b/webClient/package.json
@@ -46,7 +46,7 @@
     "exports-loader": "~0.7.0",
     "file-loader": "~1.1.11",
     "html-loader": "~0.5.5",
-    "node-sass": "~4.11.0",
+    "node-sass": "~4.12.0",
     "rxjs": "~6.2.2",
     "rxjs-compat": "~6.2.2",
     "sass-loader": "~7.1.0",


### PR DESCRIPTION
node-sass v4.11 is not compatible with node v12 at this moment. Upgrading it to 4.12 solves the issue.