### PR TITLE
Reformatting the Save As Modal - (Solves - #382)

### DIFF
--- a/webClient/src/app/shared/dialog/save-to/save-to.component.html
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.html
@@ -8,6 +8,9 @@
   
   Copyright Contributors to the Zowe Project.
 -->
+<mat-dialog-actions>
+  <button mat-dialog-close class="right cross-button"><i class="fa fa-close"></i></button>
+</mat-dialog-actions>
 <h2 mat-dialog-title>Save As</h2>
 <mat-dialog-content>
   <label>Directory:</label>
@@ -29,7 +32,7 @@
   </mat-form-field>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close class="right">Cancel</button>
+  <button mat-dialog-close class="right cancel-button">Cancel</button>
   <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
   <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="results">Save</button>
 </mat-dialog-actions>

--- a/webClient/src/app/shared/dialog/save-to/save-to.component.html
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.html
@@ -10,19 +10,19 @@
 -->
 <h2 mat-dialog-title>Save As</h2>
 <mat-dialog-content>
-  Directory:
+  <label>Directory:</label>
   <mat-form-field>
-    <input matInput type="text" placeholder="Enter a directory" [(ngModel)]="results.directory">
+    <input matInput type="text" placeholder="" [(ngModel)]="results.directory">
   </mat-form-field>
   <p></p>
-  File Name:
-  <mat-form-field>
-    <input matInput type="text" placeholder="Enter a file name" [(ngModel)]="results.fileName">
+  <label>File Name:</label>
+  <mat-form-field class="align-label">
+    <input matInput type="text" placeholder="" [(ngModel)]="results.fileName">
   </mat-form-field>
   <p></p>
-  Encoding:
+  <label>Encoding:</label>
   <mat-form-field>
-    <mat-select placeholder="Select An Encoding" [(ngModel)]="results.encoding">
+    <mat-select placeholder="Select" [(ngModel)]="results.encoding">
       <mat-option *ngFor="let option of options" [value]="option">
       {{option}}</mat-option>
     </mat-select>

--- a/webClient/src/app/shared/dialog/save-to/save-to.component.scss
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.scss
@@ -9,15 +9,15 @@
   Copyright Contributors to the Zowe Project.
 */
 mat-dialog-actions {
-    justify-content: flex-end;
+  justify-content: flex-end;
 }
 
 .mat-form-field {
-    padding-inline: center;
+  padding-inline: inherit;
 }
 
 .align-label {
-    padding-left: 18px;
+  padding-left: 18px;
 }
 
 /*

--- a/webClient/src/app/shared/dialog/save-to/save-to.component.scss
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.scss
@@ -11,6 +11,15 @@
 mat-dialog-actions {
     justify-content: flex-end;
 }
+
+.mat-form-field {
+    padding-inline: center;
+}
+
+.align-label {
+    padding-left: 18px;
+}
+
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies

--- a/webClient/src/app/shared/dialog/save-to/save-to.component.scss
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.scss
@@ -20,6 +20,23 @@ mat-dialog-actions {
   padding-left: 18px;
 }
 
+.cancel-button {
+  border: none;
+  min-width: 88px;
+  line-height: 36px;
+  padding: 0 16px;
+  background: white;
+  color: black;
+}
+
+.cross-button {
+  border: none;
+  color: black;
+  background: white;
+  margin-top: -30px;
+  outline: 0;
+}
+
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies


### PR DESCRIPTION
This changes the `Save As Modal` as per the requirements
The new Save As modal looks like:
![Screenshot from 2020-01-27 23-46-50](https://user-images.githubusercontent.com/34754265/73202609-64fa9b80-4161-11ea-90e4-ac521bee7b4d.png)

Solves: https://github.com/zowe/zlux/issues/382