### PR TITLE
Adding snackbar notification for directory error - (Solves - #375)

### DIFF
--- a/webClient/src/app/shared/dialog/open-folder/open-folder.component.html
+++ b/webClient/src/app/shared/dialog/open-folder/open-folder.component.html
@@ -21,7 +21,7 @@
 <mat-dialog-actions>
   <button mat-button mat-dialog-close class="right">Cancel</button>
   <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
-  <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="value" [disabled]="!value">Open</button>
+  <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="value" [disabled]="!value" (click)="openFile()">Open</button>
 </mat-dialog-actions>
 
 <!-- 

--- a/webClient/src/app/shared/dialog/open-folder/open-folder.component.ts
+++ b/webClient/src/app/shared/dialog/open-folder/open-folder.component.ts
@@ -12,6 +12,8 @@ import { Component, OnInit } from '@angular/core';
 import { MatDialogRef } from '@angular/material';
 import { HttpService } from '../../http/http.service';
 import { ENDPOINTS } from '../../../../environments/environment';
+import { SnackBarService } from '../../snack-bar.service';
+
 
 @Component({
   selector: 'app-open-folder',
@@ -23,11 +25,17 @@ export class OpenFolderComponent implements OnInit {
   private fetching = false;
   private value = '/';
 
-  constructor(private http: HttpService, private dialogRef: MatDialogRef<OpenFolderComponent>) { }
+  constructor(private http: HttpService, private dialogRef: MatDialogRef<OpenFolderComponent>, private snackBar: SnackBarService) { }
 
   ngOnInit() {
   }
-}
+
+  openFile(){
+    this.snackBar.open("File Not Found!","", { 
+      duration: 2000,
+    });
+  }
+} 
 
 /*
   This program and the accompanying materials are

--- a/webClient/src/app/shared/dialog/open-folder/open-folder.component.ts
+++ b/webClient/src/app/shared/dialog/open-folder/open-folder.component.ts
@@ -32,7 +32,7 @@ export class OpenFolderComponent implements OnInit {
 
   openFile(){
     this.snackBar.open("File Not Found!","", { 
-      duration: 2000,
+      duration: 2000, 
     });
   }
 } 


### PR DESCRIPTION
This will add a `snackbar` notification when a directory does not open.
The execution of opening a directory is not implemeted yet, so I am adding a traditional `File not found` message when the directory is not opened.
The notifications can be modified according to the error codes or other response when implementation is added.