### PR TITLE
Reformatting the save-as modal for the new prototype

### DIFF
--- a/webClient/src/app/shared/dialog/save-to/save-to.component.html
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.html
@@ -9,7 +9,9 @@
   Copyright Contributors to the Zowe Project.
 -->
 <mat-dialog-actions>
-  <button mat-dialog-close class="right cross-button"><i class="fa fa-close"></i></button>
+  <button mat-dialog-close class="right cross-button">
+    <mat-icon>close</mat-icon>
+  </button>
 </mat-dialog-actions>
 <h2 mat-dialog-title>Save As</h2>
 <mat-dialog-content>

--- a/webClient/src/app/shared/dialog/save-to/save-to.component.html
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.html
@@ -1,26 +1,29 @@
 
-<!-- 
+<!--
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 -->
+<mat-dialog-actions>
+  <button mat-dialog-close class="right cross-button"><i class="fa fa-close"></i></button>
+</mat-dialog-actions>
 <h2 mat-dialog-title>Save As</h2>
 <mat-dialog-content>
-  File Name:
+  <label>File Name:</label>
   <mat-form-field>
     <input matInput type="text" placeholder="Enter a file name" [(ngModel)]="results.fileName">
   </mat-form-field>
   <p></p>
-  Directory:
-  <mat-form-field>
-    <input matInput type="text" placeholder="Enter a directory" [(ngModel)]="results.directory">
+  <label>Directory:</label>
+  <mat-form-field class="align-label">
+    <input matInput type="text" placeholder="" [(ngModel)]="results.directory">
   </mat-form-field>
   <p></p>
-  Encoding:
+  <label>Encoding:</label>
   <mat-form-field>
     <mat-select placeholder="Select An Encoding" [(ngModel)]="results.encoding">
       <mat-option *ngFor="let option of options" [value]="option">
@@ -29,17 +32,17 @@
   </mat-form-field>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close class="right">Cancel</button>
+  <button mat-dialog-close class="right cancel-button">Cancel</button>
   <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
   <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="results">Save</button>
 </mat-dialog-actions>
 
-<!-- 
+<!--
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 -->

--- a/webClient/src/app/shared/dialog/save-to/save-to.component.scss
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.scss
@@ -3,20 +3,47 @@
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 */
 mat-dialog-actions {
-    justify-content: flex-end;
+  justify-content: flex-end;
 }
+
+.mat-form-field {
+  padding-inline: inherit;
+}
+
+.align-label {
+  padding-left: 30px;
+}
+
+.cancel-button {
+  border: none;
+  min-width: 88px;
+  line-height: 36px;
+  padding: 0 16px;
+  background: white;
+  color: black;
+  outline: 0;
+}
+
+.cross-button {
+  border: none;
+  color: black;
+  background: white;
+  margin-top: -30px;
+  outline: 0;
+}
+
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 */

--- a/webClient/src/app/shared/dialog/save-to/save-to.component.scss
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.scss
@@ -31,7 +31,7 @@ mat-dialog-actions {
   color: black;
   background: white;
   margin-top: -30px;
-  margin-right: -17px
+  margin-right: -17px;
   outline: 0;
 }
 

--- a/webClient/src/app/shared/dialog/save-to/save-to.component.scss
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.scss
@@ -12,10 +12,6 @@ mat-dialog-actions {
   justify-content: flex-end;
 }
 
-.mat-form-field {
-  padding-inline: inherit;
-}
-
 .align-label {
   padding-left: 30px;
 }
@@ -35,6 +31,7 @@ mat-dialog-actions {
   color: black;
   background: white;
   margin-top: -30px;
+  margin-right: -17px
   outline: 0;
 }
 


### PR DESCRIPTION
This changes the Save As Modal as per the requirements
The new Save As modal looks like:
![Screenshot from 2020-01-31 00-04-52](https://user-images.githubusercontent.com/34754265/73479118-590b1580-43bd-11ea-8f77-23728dc09070.png)
This solves, https://github.com/zowe/zlux/issues/382