### PR TITLE
Adding minified notification for the open directory option 

### DIFF
--- a/webClient/src/app/shared/dialog/open-folder/open-folder.component.html
+++ b/webClient/src/app/shared/dialog/open-folder/open-folder.component.html
@@ -1,11 +1,11 @@
 
-<!-- 
+<!--
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 -->
 <h2 mat-dialog-title>Open Directory</h2>
@@ -21,15 +21,15 @@
 <mat-dialog-actions>
   <button mat-button mat-dialog-close class="right">Cancel</button>
   <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
-  <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="value" [disabled]="!value">Open</button>
+  <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="value" [disabled]="!value" (click)="openFile()">Open</button>
 </mat-dialog-actions>
 
-<!-- 
+<!--
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 -->

--- a/webClient/src/app/shared/dialog/open-folder/open-folder.component.ts
+++ b/webClient/src/app/shared/dialog/open-folder/open-folder.component.ts
@@ -3,15 +3,16 @@
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 */
 import { Component, OnInit } from '@angular/core';
 import { MatDialogRef } from '@angular/material';
 import { HttpService } from '../../http/http.service';
 import { ENDPOINTS } from '../../../../environments/environment';
+import { SnackBarService } from '../../snack-bar.service';
 
 @Component({
   selector: 'app-open-folder',
@@ -23,9 +24,15 @@ export class OpenFolderComponent implements OnInit {
   private fetching = false;
   private value = '/';
 
-  constructor(private http: HttpService, private dialogRef: MatDialogRef<OpenFolderComponent>) { }
+  constructor(private http: HttpService, private dialogRef: MatDialogRef<OpenFolderComponent>, private snackBar: SnackBarService) { }
 
   ngOnInit() {
+  }
+
+  openFile(){
+      this.snackBar.open("File Not Found!","", {
+          duration: 2000,
+      });
   }
 }
 
@@ -33,8 +40,8 @@ export class OpenFolderComponent implements OnInit {
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 */


### PR DESCRIPTION
This will add a snackbar notification when a directory does not open.
The execution of opening a directory is not implemeted yet, so I am adding a traditional File not found message when the directory is not opened.
The notifications can be modified according to the error codes or other response when implementation is added.
![73288048-46a7a500-4220-11ea-9db2-930869c27116](https://user-images.githubusercontent.com/34754265/73597467-4ece5000-4552-11ea-9d3e-49ddfcde425e.gif)

This solves zowe/zlux#375
