### PR TITLE
Remove File's Open Tab When File Deletes

### DIFF
--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -171,14 +171,7 @@ export class ProjectTreeComponent {
     });
 
     this.editorControl.deleteFile.subscribe(pathAndName => {
-      const openedFileContext = this.editorControl.openFileList.getValue().find(fileContext => {
-        return pathAndName === `${fileContext.model.path}/${fileContext.model.fileName}`
-      });
-      if (!openedFileContext) this.deleteAndCloseFile(pathAndName, null);
-      else if (openedFileContext.active) {
-        this.snackBarService.open('File ' + name + ' cannot be deleted because it is currently open.',
-          'Dismiss', { duration: 5000,   panelClass: 'center' });
-      } else this.deleteAndCloseFile(pathAndName, openedFileContext);
+      this.fileExplorer.deleteFileOrFolder(pathAndName);
     });
 
     this.editorControl.createDirectory.subscribe(pathAndName => {
@@ -186,8 +179,8 @@ export class ProjectTreeComponent {
     });
   }
 
-  deleteAndCloseFile(pathAndName: string, openedFileContext?: ProjectContext) {
-    let deleteObservable = this.fileExplorer.deleteFileOrFolder(pathAndName);
+  deleteAndCloseFile(file: any, openedFileContext?: ProjectContext) {
+    let deleteObservable = this.fileExplorer.deleteFileOrFolder(file);
     if (openedFileContext != null)
       deleteObservable.subscribe(() => {
         this.editorControl.closeFileHandler(openedFileContext);
@@ -200,7 +193,15 @@ export class ProjectTreeComponent {
   }
 
   onDeleteClick($event: any){
-    // Todo: Create right click menu functionality.
+    const file = $event.file;
+    const openedFileContext = this.editorControl.openFileList.getValue().find(fileContext => {
+      return file.path === `${fileContext.model.path}/${fileContext.model.fileName}`
+    });
+    if (!openedFileContext) this.deleteAndCloseFile(file, null);
+      else if (openedFileContext.active) {
+        this.snackBarService.open('File ' + name + ' cannot be deleted because it is currently open.',
+          'Dismiss', { duration: 5000,   panelClass: 'center' });
+      } else this.deleteAndCloseFile(file, openedFileContext);
   }
 
   onNewFileClick($event: any){

--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -170,7 +170,17 @@ export class ProjectTreeComponent {
     });
 
     this.editorControl.deleteFile.subscribe(pathAndName => {
-      this.fileExplorer.deleteFileOrFolder(pathAndName);
+      const openedFileContext = this.editorControl.openFileList.getValue().find(fileContext => {
+        return pathAndName === `${fileContext.model.path}/${fileContext.model.fileName}`
+      })
+      if (!openedFileContext) this.fileExplorer.deleteFileOrFolder(pathAndName);
+      else if (openedFileContext.active) {
+        this.snackBarService.open('File ' + name + ' cannot be deleted because it is currently open.',
+          'Dismiss', { duration: 5000,   panelClass: 'center' });
+      } else {
+        this.fileExplorer.deleteFileOrFolder(pathAndName);
+        // TODO: remove opened tab... need to subscribe to delete observable
+      }
     });
 
     this.editorControl.createDirectory.subscribe(pathAndName => {


### PR DESCRIPTION
Fixes https://github.com/zowe/zlux/issues/381

Stuffs fixed:
- [x] if a given file is opened and selected, show a snackbar saying that the file can't be deleted.
- [x] if a given file is opened but not selected, close the tab automatically if deleted successfully.

Pre-requisite PRs:
- https://github.com/zowe/zlux-file-explorer/pull/62