### PR TITLE
Reformatting the save-to modal for the new prototye.

### DIFF
--- a/webClient/src/app/shared/dialog/save-to/save-to.component.html
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.html
@@ -8,28 +8,33 @@
   
   Copyright Contributors to the Zowe Project.
 -->
+<mat-dialog-actions>
+  <button mat-dialog-close class="right cross-button">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>
 <h2 mat-dialog-title>Save As</h2>
 <mat-dialog-content>
-  File Name:
-  <mat-form-field>
-    <input matInput type="text" placeholder="Enter a file name" [(ngModel)]="results.fileName">
+  <label>Directory:</label>
+  <mat-form-field class="align-label">
+    <input matInput type="text" placeholder="" [(ngModel)]="results.directory">
   </mat-form-field>
   <p></p>
-  Directory:
+  <label>File Name:</label>
   <mat-form-field>
-    <input matInput type="text" placeholder="Enter a directory" [(ngModel)]="results.directory">
+    <input matInput type="text" placeholder="" [(ngModel)]="results.fileName">
   </mat-form-field>
   <p></p>
-  Encoding:
-  <mat-form-field>
-    <mat-select placeholder="Select An Encoding" [(ngModel)]="results.encoding">
+  <label>Encoding:</label>
+  <mat-form-field class="align-encoding">
+    <mat-select placeholder="Select" [(ngModel)]="results.encoding">
       <mat-option *ngFor="let option of options" [value]="option">
       {{option}}</mat-option>
     </mat-select>
   </mat-form-field>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close class="right">Cancel</button>
+  <button mat-dialog-close class="right cancel-button">Cancel</button>
   <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
   <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="results">Save</button>
 </mat-dialog-actions>

--- a/webClient/src/app/shared/dialog/save-to/save-to.component.scss
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.scss
@@ -1,4 +1,3 @@
-
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
@@ -10,37 +9,6 @@
 */
 mat-dialog-actions {
     justify-content: flex-end;
-}
-
-.mat-form-field {
-margin-left: 30px;
-}
-
-.align-label {
-  margin-left: 36px;
-}
-
-.align-encoding {
-  margin-left: 34px;
-}
-
-.cancel-button {
-  border: none;
-  min-width: 88px;
-  line-height: 36px;
-  padding: 0 16px;
-  background: white;
-  color: black;
-  outline: 0;
-}
-
-.cross-button {
-  border: none;
-  color: black;
-  background: white;
-  margin-top: -30px;
-  margin-right: -16px;
-  outline: 0;
 }
 
 /*

--- a/webClient/src/app/shared/dialog/save-to/save-to.component.scss
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.scss
@@ -11,6 +11,38 @@
 mat-dialog-actions {
     justify-content: flex-end;
 }
+
+.mat-form-field {
+margin-left: 30px;
+}
+
+.align-label {
+  margin-left: 36px;
+}
+
+.align-encoding {
+  margin-left: 34px;
+}
+
+.cancel-button {
+  border: none;
+  min-width: 88px;
+  line-height: 36px;
+  padding: 0 16px;
+  background: white;
+  color: black;
+  outline: 0;
+}
+
+.cross-button {
+  border: none;
+  color: black;
+  background: white;
+  margin-top: -30px;
+  margin-right: -16px;
+  outline: 0;
+}
+
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies

--- a/webClient/src/styles/global.css
+++ b/webClient/src/styles/global.css
@@ -2142,6 +2142,39 @@ input.mat-input-element {
     color: #3f51b5;
 }
 
+.mat-form-field {
+  margin-left: 30px;
+  }
+  
+  .align-label {
+    margin-left: 36px;
+  }
+  
+  .align-encoding {
+    margin-left: 34px;
+  }
+  
+  .cancel-button {
+    border: none;
+    min-width: 88px;
+    line-height: 36px;
+    padding: 0 16px;
+    background: transparent;
+    color: black;
+    outline: 0;
+  }
+  
+  .cross-button {
+    border: none;
+    color: black;
+    background: transparent;
+    margin-top: -30px;
+    margin-right: -16px;
+    outline: 0;
+  }
+  
+  
+
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies


### PR DESCRIPTION
This changes the Save To Modal as per the requirements of the new prototype.
The new Save To modal looks like:
![Screenshot from 2020-03-03 01-21-46](https://user-images.githubusercontent.com/34754265/75712079-6170ac00-5ced-11ea-9df3-b81f986d246a.png)
This solves, zowe/zlux#382