### PR TITLE
Added close all + undo setting + hotkey

### DIFF
--- a/webClient/src/app/core/menu-bar/menu-bar.config.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.config.ts
@@ -176,7 +176,17 @@ export const MENU = [
                     internalName: 'saveFile'
                 },
                 keyMap: 'Ctrl+S'
-            },              
+            },   
+            {
+              name: 'group-end'
+            },
+            {
+              name: 'Close All',
+              action: {
+                  internalName: 'closeAll'
+              },
+              keyMap: 'Alt+W+Shift'
+            },        
             //{
             //    name: 'Save All',
             //    action: {

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -125,16 +125,16 @@ export class MonacoService {
           });
         },
         error: (err) => {
-          this.log.warn(`${fileNode.name} could not be opened`);
+          this.log.warn(`${fileNode.name} could not be opened, status: `, err.status);
           if (err.status === 403) {
-            this.snackBar.open(`${fileNode.name} could not be opened due to permissions`,
-              'Close', { duration: MessageDuration.Short, panelClass: 'center' });
+            this.snackBar.open(`${fileNode.name} could not be opened due to permissions.`,
+              'Close', { duration: MessageDuration.Medium, panelClass: 'center' });
           } else if (err.status === 404) {
-            this.snackBar.open(`${fileNode.name} could not be found`,
-              'Close', { duration: MessageDuration.Short, panelClass: 'center' });
+            this.snackBar.open(`${fileNode.name} could not be found.`,
+              'Close', { duration: MessageDuration.Medium, panelClass: 'center' });
           } else {
-            this.snackBar.open(`${fileNode.name} could not be opened`,
-              'Close', { duration: MessageDuration.Short, panelClass: 'center' });
+            this.snackBar.open(`${fileNode.name} could not be opened.`,
+              'Close', { duration: MessageDuration.Medium, panelClass: 'center' });
           }
         }
       });

--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -104,6 +104,13 @@ export class ProjectTreeComponent {
       this.nodes = nodes;
     });
 
+    this.editorControl.closeAllFiles.subscribe(() => {
+      this.editorControl.closeAllHandler();
+    });
+
+    this.editorControl.undoCloseAllFiles.subscribe(() => {
+      this.editorControl.undoCloseAllHandler();
+    })
 
     this.editorControl.openProject.subscribe(projectName => {
       if (projectName != null) {

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -238,11 +238,10 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     this.previousSessionData.stateCache = stateCache;
     /* As our cached list, we save all files *minus* the previously opened file. This is because
     that file will get opened as the last editor file in code-editor.component */
-    this.previousSessionData._openFileList = this._openFileList.getValue().slice(0, this._openFileList.getValue().length-1); //pop breaks things here
+    this.previousSessionData._openFileList = this._openFileList.getValue().slice(0, this._openFileList.getValue().length-1); //Pop breaks things here so slice
 
     this.log.debug('Clearing all cache for files');
     stateCache = {};
-    //TODO: _openFileList is our storage mechanism for tabs open, we can save this as a copy for later to create a "Revert"/"Undo" feature
     let currentOpenFileList = new Array<ProjectContext>(0);
     this._openFileList.next(currentOpenFileList);
   }
@@ -255,7 +254,6 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     if (this.previousSessionData._openFileList) {
       if (this.previousSessionData._openFileList.length > 0) {
         this._openFileList.next(this.previousSessionData._openFileList);
-        //this.openFileHandler(this._openFileList.getValue()[this._openFileList.getValue().length-1])
       } else {
         this._openFileList.next(this.previousSessionData._openFileList);
       }

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -218,7 +218,10 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
       fileContext.active ? this.log.warn(`File ${fileContext.name} already active.`) : fileContext.active = true;
     }
     let currentOpenFileList = this._openFileList.getValue();
-    currentOpenFileList.push(fileContext);
+    if (!(currentOpenFileList.filter(function(e) { return e.name === fileContext.name && e.id === fileContext.id; }).length > 0)) {
+      /* vendors contains the element we're looking for */
+      currentOpenFileList.push(fileContext);
+    }
     this._openFileList.next(currentOpenFileList);
   }
 
@@ -238,7 +241,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     this.previousSessionData.stateCache = stateCache;
     /* As our cached list, we save all files *minus* the previously opened file. This is because
     that file will get opened as the last editor file in code-editor.component */
-    this.previousSessionData._openFileList = this._openFileList.getValue().slice(0, this._openFileList.getValue().length-1); //Pop breaks things here so slice
+    this.previousSessionData._openFileList = this._openFileList.getValue(); //Pop breaks things here so slice
 
     this.log.debug('Clearing all cache for files');
     stateCache = {};

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -219,7 +219,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     }
     let currentOpenFileList = this._openFileList.getValue();
     if (!(currentOpenFileList.filter(function(e) { return e.name === fileContext.name && e.id === fileContext.id; }).length > 0)) {
-      /* vendors contains the element we're looking for */
+      /* We only want to add this file into the list if it doesn't already belong there */
       currentOpenFileList.push(fileContext);
     }
     this._openFileList.next(currentOpenFileList);
@@ -241,7 +241,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     this.previousSessionData.stateCache = stateCache;
     /* As our cached list, we save all files *minus* the previously opened file. This is because
     that file will get opened as the last editor file in code-editor.component */
-    this.previousSessionData._openFileList = this._openFileList.getValue(); //Pop breaks things here so slice
+    this.previousSessionData._openFileList = this._openFileList.getValue();
 
     this.log.debug('Clearing all cache for files');
     stateCache = {};
@@ -255,11 +255,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
       stateCache = this.previousSessionData.stateCache;
     }
     if (this.previousSessionData._openFileList) {
-      if (this.previousSessionData._openFileList.length > 0) {
-        this._openFileList.next(this.previousSessionData._openFileList);
-      } else {
-        this._openFileList.next(this.previousSessionData._openFileList);
-      }
+      this._openFileList.next(this.previousSessionData._openFileList);
     }
   }
 

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -228,8 +228,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
       this.log.debug(`Clearing cache for`,cacheFileName);
       delete stateCache[cacheFileName];
     }
-    !fileContext.opened ? this.log.warn(`File ${
-    fileContext.name} already closed.`) : fileContext.opened = false;
+    !fileContext.opened ? this.log.warn(`File ${fileContext.name} already closed.`) : fileContext.opened = false;
     !fileContext.active ? this.log.warn(`File ${fileContext.name} already inactive.`) : fileContext.active = false;
     fileContext.changed = false;
     this._openFileList.next(this._openFileList.getValue().filter((file) => (file.model.fileName !== fileContext.model.fileName || file.model.path !== fileContext.model.path)));

--- a/webClient/src/app/shared/message-duration.ts
+++ b/webClient/src/app/shared/message-duration.ts
@@ -9,7 +9,7 @@
 */
 
 export class MessageDuration {
-  static Short: number = 2000;
+  static Short: number = 3000;
 
   static Medium: number = 6000;
 


### PR DESCRIPTION
- Globally increases the shortest duration of snackbar notifications from 2s -> 3s
- Added a "Close All" button in the menu (hotkey is Alt + W + Shift)
- Added a snackbar notification for opening a folder/file you don't have access to
(PR here: https://github.com/zowe/zlux-file-explorer/pull/75)
- Added an "Undo" option to the Close All feature to re-open tabs & files upon accidental missclick

![image](https://user-images.githubusercontent.com/20528015/83287594-f03b7a80-a1af-11ea-997b-358647cb7b6e.png)

![image](https://user-images.githubusercontent.com/20528015/83287542-def26e00-a1af-11ea-9079-4d19f57de49c.png)


Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>