### PR TITLE
Feature/Restore last opened files

### DIFF
--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -27,6 +27,9 @@
         "subResources": {
           "history": {
             "aggregationPolicy": "override"
+          },
+          "openTabs": {
+            "aggregationPolicy": "override"
           }
         }
       }

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -49,7 +49,7 @@ export class AppComponent {
     let activeZluxEditorsCount : number
     let dataToSave : string
     if(openWindowsStorageString){
-      (Date.now() - +openWindowsStorageString.split(":")[1]) < (60*60*24*1000) ? activeZluxEditorsCount = +openWindowsStorageString.split(":")[0] + 1 : activeZluxEditorsCount = 1
+      (+window.localStorage.getItem("ZoweZLUX.lastActive") - +openWindowsStorageString.split(":")[1]) < +window.localStorage.getItem("ZoweZLUX.expirationTime") ? activeZluxEditorsCount = +openWindowsStorageString.split(":")[0] + 1 : activeZluxEditorsCount = 1
     }else{
       activeZluxEditorsCount = 1
     }

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -45,13 +45,21 @@ export class AppComponent {
   }
 
   ngOnInit() {
-    let activeZluxEditors : number = +window.localStorage.getItem("activeZluxEditors")
-    activeZluxEditors > 0 ? activeZluxEditors++ : activeZluxEditors = 1 
-    window.localStorage.setItem("activeZluxEditors",activeZluxEditors.toString())
+    let openWindowsStorageString : string = window.localStorage.getItem("org.zowe.editor-openWindows")
+    let activeZluxEditorsCount : number
+    let dataToSave : string
+    if(openWindowsStorageString){
+      (Date.now() - +openWindowsStorageString.split(":")[1]) < (60*60*24*1000) ? activeZluxEditorsCount = +openWindowsStorageString.split(":")[0] + 1 : activeZluxEditorsCount = 1
+    }else{
+      activeZluxEditorsCount = 1
+    }
+    dataToSave = activeZluxEditorsCount.toString() + ":" + Date.now() 
+    window.localStorage.setItem("org.zowe.editor-openWindows",dataToSave)
     window.addEventListener("beforeunload", () => { 
-      activeZluxEditors = +window.localStorage.getItem("activeZluxEditors")
-      activeZluxEditors - 1 > -1 ? activeZluxEditors-- : activeZluxEditors = 0;
-      localStorage.setItem("activeZluxEditors",activeZluxEditors.toString())
+      activeZluxEditorsCount = +window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0]
+      activeZluxEditorsCount - 1 > -1 ? activeZluxEditorsCount-- : activeZluxEditorsCount = 0;
+      dataToSave = activeZluxEditorsCount.toString() + ":" + Date.now() 
+      localStorage.setItem("org.zowe.editor-openWindows",dataToSave)
     });
 
     if (this.launchMetadata && this.launchMetadata.data && this.launchMetadata.data.type) {
@@ -61,7 +69,7 @@ export class AppComponent {
     const editorheaderElement = this.editorheaderElementRef.nativeElement;
     this.appKeyboard.registerKeyUpEvent(editorheaderElement);
     
-    if(activeZluxEditors < 2){
+    if(activeZluxEditorsCount < 2){
       let plugin : ZLUX.Plugin = this.pluginDefinition.getBasePlugin()
       let filePath : string = 'ui/openTabs'
       let fileName : string = 'fileList'
@@ -169,9 +177,10 @@ export class AppComponent {
   }
 
   ngOnDestroy(){
-    let activeZluxEditors : number  = +window.localStorage.getItem("activeZluxEditors")
+    let activeZluxEditors : number  = +window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0]
     activeZluxEditors - 1 > -1 ? activeZluxEditors-- : activeZluxEditors = 0;
-    window.localStorage.setItem("activeZluxEditors",activeZluxEditors.toString())
+    let dataToSave = activeZluxEditors.toString() + ":" + Date.now() 
+    window.localStorage.setItem("org.zowe.editor-openWindows",dataToSave)
   }
 
 }

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -64,7 +64,7 @@ export class AppComponent {
       let fileName : string = 'fileList'
       this.HTTP.get<any>(ZoweZLUX.uriBroker.pluginConfigUri(plugin,filePath,fileName)).subscribe(res => {
         if(res){
-          this.editorControl.numberOfTabsToRestore = res.contents.files.length - 1
+          res.contents.files.length - 1 > -1 ? this.editorControl.numberOfTabsToRestore = res.contents.files.length - 1 : this.editorControl.numberOfTabsToRestore = 0
           res.contents.files.forEach(file => {
             if(file[0] == '/' && file.startsWith("//'") == false){
               file = file.slice(1);

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -42,9 +42,6 @@ export class AppComponent {
               @Inject(Angular2InjectionTokens.PLUGIN_DEFINITION) private pluginDefinition: ZLUX.ContainerPluginDefinition,
               private HTTP: HttpClient) {
     this.log.debug(`Monaco object=`,monaco);
-  }
-
-  ngOnInit() {
     let openWindowsStorageString : string = window.localStorage.getItem("org.zowe.editor-openWindows")
     let activeZluxEditorsCount : number
     let dataToSave : string
@@ -61,14 +58,6 @@ export class AppComponent {
       dataToSave = activeZluxEditorsCount.toString() + ":" + Date.now() 
       localStorage.setItem("org.zowe.editor-openWindows",dataToSave)
     });
-
-    if (this.launchMetadata && this.launchMetadata.data && this.launchMetadata.data.type) {
-      this.handleLaunchOrMessageObject(this.launchMetadata.data);
-    }
-
-    const editorheaderElement = this.editorheaderElementRef.nativeElement;
-    this.appKeyboard.registerKeyUpEvent(editorheaderElement);
-    
     if(activeZluxEditorsCount < 2){
       let plugin : ZLUX.Plugin = this.pluginDefinition.getBasePlugin()
       let filePath : string = 'ui/openTabs'
@@ -84,6 +73,15 @@ export class AppComponent {
         }
       });
     }
+  }
+
+  ngOnInit() {
+    if (this.launchMetadata && this.launchMetadata.data && this.launchMetadata.data.type) {
+      this.handleLaunchOrMessageObject(this.launchMetadata.data);
+    }
+
+    const editorheaderElement = this.editorheaderElementRef.nativeElement;
+    this.appKeyboard.registerKeyUpEvent(editorheaderElement);
   }
 
   handleLaunchOrMessageObject(data: any) {

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -42,7 +42,7 @@ export class AppComponent {
               @Inject(Angular2InjectionTokens.PLUGIN_DEFINITION) private pluginDefinition: ZLUX.ContainerPluginDefinition,
               private HTTP: HttpClient) {
     this.log.debug(`Monaco object=`,monaco);
-    let openWindowsStorageString : string = window.localStorage.getItem("org.zowe.editor-openWindows")
+    let openWindowsStorageString : string = window.localStorage.getItem(this.pluginDefinition.getBasePlugin().getIdentifier()+"-openWindows")
     let activeZluxEditorsCount : number
     let dataToSave : string
     if(openWindowsStorageString){
@@ -51,13 +51,8 @@ export class AppComponent {
       activeZluxEditorsCount = 1
     }
     dataToSave = activeZluxEditorsCount.toString() + ":" + Date.now() 
-    window.localStorage.setItem("org.zowe.editor-openWindows",dataToSave)
-    window.addEventListener("beforeunload", () => { 
-      activeZluxEditorsCount = +window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0]
-      activeZluxEditorsCount - 1 > -1 ? activeZluxEditorsCount-- : activeZluxEditorsCount = 0;
-      dataToSave = activeZluxEditorsCount.toString() + ":" + Date.now() 
-      localStorage.setItem("org.zowe.editor-openWindows",dataToSave)
-    });
+    window.localStorage.setItem(this.pluginDefinition.getBasePlugin().getIdentifier()+"-openWindows",dataToSave)
+    window.addEventListener("beforeunload",this.resetActiveEditorsCount);
     if(activeZluxEditorsCount < 2){
       let plugin : ZLUX.Plugin = this.pluginDefinition.getBasePlugin()
       let filePath : string = 'ui/openTabs'
@@ -176,11 +171,16 @@ export class AppComponent {
     }
   }
 
-  ngOnDestroy(){
-    let activeZluxEditors : number  = +window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0]
+  resetActiveEditorsCount = function(){
+    let activeZluxEditors : number  = +window.localStorage.getItem(this.pluginDefinition.getBasePlugin().getIdentifier()+"-openWindows").split(":")[0]
     activeZluxEditors - 1 > -1 ? activeZluxEditors-- : activeZluxEditors = 0;
     let dataToSave = activeZluxEditors.toString() + ":" + Date.now() 
-    window.localStorage.setItem("org.zowe.editor-openWindows",dataToSave)
+    window.localStorage.setItem(this.pluginDefinition.getBasePlugin().getIdentifier()+"-openWindows",dataToSave)
+  }
+
+  ngOnDestroy(){
+    this.resetActiveEditorsCount();
+    window.removeEventListener("beforeunload",this.resetActiveEditorsCount);
   }
 
 }

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -45,6 +45,15 @@ export class AppComponent {
   }
 
   ngOnInit() {
+    let activeZluxEditors : number = +window.localStorage.getItem("activeZluxEditors")
+    activeZluxEditors > 0 ? activeZluxEditors++ : activeZluxEditors = 1 
+    window.localStorage.setItem("activeZluxEditors",activeZluxEditors.toString())
+    window.addEventListener("beforeunload", () => { 
+      activeZluxEditors = +window.localStorage.getItem("activeZluxEditors")
+      activeZluxEditors - 1 > -1 ? activeZluxEditors-- : activeZluxEditors = 0;
+      localStorage.setItem("activeZluxEditors",activeZluxEditors.toString())
+    });
+
     if (this.launchMetadata && this.launchMetadata.data && this.launchMetadata.data.type) {
       this.handleLaunchOrMessageObject(this.launchMetadata.data);
     }
@@ -52,19 +61,21 @@ export class AppComponent {
     const editorheaderElement = this.editorheaderElementRef.nativeElement;
     this.appKeyboard.registerKeyUpEvent(editorheaderElement);
     
-    let plugin : ZLUX.Plugin = this.pluginDefinition.getBasePlugin()
-    let filePath : string = 'ui/openTabs'
-    let fileName : string = 'fileList'
-    this.HTTP.get<any>(ZoweZLUX.uriBroker.pluginConfigUri(plugin,filePath,fileName)).subscribe(res => {
-      if(res){
-        res.contents.files.forEach(file => {
-          if(file[0] == '/' && file.startsWith("//'") == false){
-            file = file.slice(1);
-          }
-          this.handleLaunchOrMessageObject({'type':'openFile','name':file});         
-        });
-      }
-    });
+    if(activeZluxEditors < 2){
+      let plugin : ZLUX.Plugin = this.pluginDefinition.getBasePlugin()
+      let filePath : string = 'ui/openTabs'
+      let fileName : string = 'fileList'
+      this.HTTP.get<any>(ZoweZLUX.uriBroker.pluginConfigUri(plugin,filePath,fileName)).subscribe(res => {
+        if(res){
+          res.contents.files.forEach(file => {
+            if(file[0] == '/' && file.startsWith("//'") == false){
+              file = file.slice(1);
+            }
+            this.handleLaunchOrMessageObject({'type':'openFile','name':file});         
+          });
+        }
+      });
+    }
   }
 
   handleLaunchOrMessageObject(data: any) {
@@ -155,6 +166,12 @@ export class AppComponent {
         return this.zluxOnMessage(eventContext);
       }      
     }
+  }
+
+  ngOnDestroy(){
+    let activeZluxEditors : number  = +window.localStorage.getItem("activeZluxEditors")
+    activeZluxEditors - 1 > -1 ? activeZluxEditors-- : activeZluxEditors = 0;
+    window.localStorage.setItem("activeZluxEditors",activeZluxEditors.toString())
   }
 
 }

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -121,8 +121,8 @@ export class AppComponent {
               if (nodes[i].fileName == fileName) {
                 this.editorControl.openFile('', nodes[i]).subscribe(x => {
                   this.log.debug(`file loaded through app2app.`);
+                  this.editorControl.numberOfTabsToRestore - 1 > -1 ? this.editorControl.numberOfTabsToRestore-- : this.editorControl.numberOfTabsToRestore = 0
                 });
-                this.editorControl.numberOfTabsToRestore - 1 > -1 ? this.editorControl.numberOfTabsToRestore-- : this.editorControl.numberOfTabsToRestore = 0
               }
             }
           }, e => {

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -64,13 +64,13 @@ export class AppComponent {
       let fileName : string = 'fileList'
       this.HTTP.get<any>(ZoweZLUX.uriBroker.pluginConfigUri(plugin,filePath,fileName)).subscribe(res => {
         if(res){
+          this.editorControl.numberOfTabsToRestore = res.contents.files.length - 1
           res.contents.files.forEach(file => {
             if(file[0] == '/' && file.startsWith("//'") == false){
               file = file.slice(1);
             }
             this.handleLaunchOrMessageObject({'type':'openFile','name':file});
           });
-          this.editorControl.numberOfTabsToRestore = res.contents.files.length - 1
         }
       });
     }

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -58,7 +58,7 @@ export class AppComponent {
     this.HTTP.get<any>(ZoweZLUX.uriBroker.pluginConfigUri(plugin,filePath,fileName)).subscribe(res => {
       if(res){
         res.contents.files.forEach(file => {
-          if(file[0] == '/'){
+          if(file[0] == '/' && file.startsWith("//'") == false){
             file = file.slice(1);
           }
           this.handleLaunchOrMessageObject({'type':'openFile','name':file});         

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -16,6 +16,7 @@ import { DataAdapterService } from './shared/http/http.data.adapter.service';
 import { UtilsService } from './shared/utils.service';
 import { EditorKeybindingService } from './shared/editor-keybinding.service';
 import * as monaco from 'monaco-editor';
+import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'app-root',
@@ -37,7 +38,9 @@ export class AppComponent {
               private httpService: HttpService,
               private utils: UtilsService,
               private editorControl: EditorControlService,
-              private appKeyboard: EditorKeybindingService) {
+              private appKeyboard: EditorKeybindingService,
+              @Inject(Angular2InjectionTokens.PLUGIN_DEFINITION) private pluginDefinition: ZLUX.ContainerPluginDefinition,
+              private HTTP: HttpClient) {
     this.log.debug(`Monaco object=`,monaco);
   }
 
@@ -48,6 +51,20 @@ export class AppComponent {
 
     const editorheaderElement = this.editorheaderElementRef.nativeElement;
     this.appKeyboard.registerKeyUpEvent(editorheaderElement);
+    
+    let plugin : ZLUX.Plugin = this.pluginDefinition.getBasePlugin()
+    let filePath : string = 'ui/openTabs'
+    let fileName : string = 'fileList'
+    this.HTTP.get<any>(ZoweZLUX.uriBroker.pluginConfigUri(plugin,filePath,fileName)).subscribe(res => {
+      if(res){
+        res.contents.files.forEach(file => {
+          if(file[0] == '/'){
+            file = file.slice(1);
+          }
+          this.handleLaunchOrMessageObject({'type':'openFile','name':file});         
+        });
+      }
+    });
   }
 
   handleLaunchOrMessageObject(data: any) {

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -68,8 +68,9 @@ export class AppComponent {
             if(file[0] == '/' && file.startsWith("//'") == false){
               file = file.slice(1);
             }
-            this.handleLaunchOrMessageObject({'type':'openFile','name':file});         
+            this.handleLaunchOrMessageObject({'type':'openFile','name':file});
           });
+          this.editorControl.numberOfTabsToRestore = res.contents.files.length - 1
         }
       });
     }
@@ -120,7 +121,8 @@ export class AppComponent {
               if (nodes[i].fileName == fileName) {
                 this.editorControl.openFile('', nodes[i]).subscribe(x => {
                   this.log.debug(`file loaded through app2app.`);
-                });                
+                });
+                this.editorControl.numberOfTabsToRestore - 1 > -1 ? this.editorControl.numberOfTabsToRestore-- : this.editorControl.numberOfTabsToRestore = 0
               }
             }
           }, e => {

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -217,7 +217,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   }
 
   private updateSavedTabsStorage(fileContext: ProjectContext){
-    let fileNameWithPath:string 
+    let fileNameWithPath:string
     if(fileContext.model.isDataset){
       fileNameWithPath = "//'" + fileContext.name + "'"
     }else{
@@ -225,14 +225,16 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     }
     if(this.openFilesAndDatasets.indexOf(fileNameWithPath) == -1 && fileContext.model.path != undefined){
       this.openFilesAndDatasets.push(fileNameWithPath)
-      this.dataToSave = {"files":this.openFilesAndDatasets}  
-      this.HTTP.put(ZoweZLUX.uriBroker.pluginConfigUri(this.plugin,this.filePath,this.fileNameToSave), this.dataToSave).subscribe();
+      this.dataToSave = {"files":this.openFilesAndDatasets}
+      if(this.numberOfTabsToRestore == 0){
+        this.HTTP.put(ZoweZLUX.uriBroker.pluginConfigUri(this.plugin,this.filePath,this.fileNameToSave), this.dataToSave).subscribe();
+      }
     }
   }
 
   //almost like selectfilehandler, except altering the list of opened files
   public openFileHandler(fileContext: ProjectContext) {
-    if(+window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0] < 2 && this.numberOfTabsToRestore == 0){
+    if(+window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0] < 2){
       this.updateSavedTabsStorage(fileContext);
     }
     for (const file of this._openFileList.getValue()) {

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -234,7 +234,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
 
   //almost like selectfilehandler, except altering the list of opened files
   public openFileHandler(fileContext: ProjectContext) {
-    if(+window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0] < 2){
+    if(+window.localStorage.getItem(this.pluginDefinition.getBasePlugin().getIdentifier()+"-openWindows").split(":")[0] < 2){
       this.updateSavedTabsStorage(fileContext);
     }
     for (const file of this._openFileList.getValue()) {
@@ -254,7 +254,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   }
 
   public closeFileHandler(fileContext: ProjectContext) {
-    if(+window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0] < 2){
+    if(+window.localStorage.getItem(this.pluginDefinition.getBasePlugin().getIdentifier()+"-openWindows").split(":")[0] < 2){
       this.openFilesAndDatasets.splice(this.openFilesAndDatasets.indexOf(fileContext.model.path+"/"+fileContext.name), 1);
       this.dataToSave = {"files":this.openFilesAndDatasets}
       this.HTTP.put(ZoweZLUX.uriBroker.pluginConfigUri(this.plugin,this.filePath,this.fileNameToSave), this.dataToSave).subscribe();

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -215,7 +215,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     return this._openFileList;
   }
 
-  private saveFilePathSessionRestore(fileContext: ProjectContext){
+  private updateSavedTabsStorage(fileContext: ProjectContext){
     let fileNameWithPath:string 
     if(fileContext.model.isDataset){
       fileNameWithPath = "//'" + fileContext.name + "'"
@@ -232,7 +232,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   //almost like selectfilehandler, except altering the list of opened files
   public openFileHandler(fileContext: ProjectContext) {
     if(+window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0] < 2){
-      this.saveFilePathSessionRestore(fileContext);
+      this.updateSavedTabsStorage(fileContext);
     }
     for (const file of this._openFileList.getValue()) {
       file.opened = false;
@@ -522,7 +522,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
           }
           return file;
         });
-      this.saveFilePathSessionRestore(_activeFile)
+      this.updateSavedTabsStorage(_activeFile)
       this.openFileList.next(fileList);
       this.openDirectory.next(results.directory);
       if (_observer != null) { _observer.next(null); }

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -223,14 +223,15 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
         }else{
          fileNameWithPath = fileContext.model.path+"/"+fileContext.name
         }
-        if(res.contents.files.indexOf(fileNameWithPath) == -1 && fileContext.model.path != undefined){
+        if(res.contents.files.indexOf(fileNameWithPath) == -1){
           res.contents.files.push(fileNameWithPath)
-          this.dataToSave = {"files":res.contents.files}
-          this.HTTP.put(ZoweZLUX.uriBroker.pluginConfigUri(this.plugin,this.filePath,this.fileNameToSave), this.dataToSave).subscribe(); 
+          this.dataToSave = {"files":res.contents.files}           
         }
       }else{
         this.dataToSave = {"files":[fileContext.model.path+"/"+fileContext.name]}
-        this.HTTP.put(ZoweZLUX.uriBroker.pluginConfigUri(this.plugin,this.filePath,this.fileNameToSave), this.dataToSave).subscribe(); 
+      }
+      if(fileContext.model.path != undefined){
+        this.HTTP.put(ZoweZLUX.uriBroker.pluginConfigUri(this.plugin,this.filePath,this.fileNameToSave), this.dataToSave).subscribe();
       }
     });
   }

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -231,7 +231,9 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
 
   //almost like selectfilehandler, except altering the list of opened files
   public openFileHandler(fileContext: ProjectContext) {
-    this.saveFilePathSessionRestore(fileContext);
+    if(+window.localStorage.getItem("activeZluxEditors") < 2){
+      this.saveFilePathSessionRestore(fileContext);
+    }
     for (const file of this._openFileList.getValue()) {
       file.opened = false;
       file.active = false;
@@ -249,9 +251,11 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   }
 
   public closeFileHandler(fileContext: ProjectContext) {
-    this.openFilesAndDatasets.splice(this.openFilesAndDatasets.indexOf(fileContext.model.path+"/"+fileContext.name), 1);
-    this.dataToSave = {"files":this.openFilesAndDatasets}
-    this.HTTP.put(ZoweZLUX.uriBroker.pluginConfigUri(this.plugin,this.filePath,this.fileNameToSave), this.dataToSave).subscribe(); 
+    if(+window.localStorage.getItem("activeZluxEditors") < 2){
+      this.openFilesAndDatasets.splice(this.openFilesAndDatasets.indexOf(fileContext.model.path+"/"+fileContext.name), 1);
+      this.dataToSave = {"files":this.openFilesAndDatasets}
+      this.HTTP.put(ZoweZLUX.uriBroker.pluginConfigUri(this.plugin,this.filePath,this.fileNameToSave), this.dataToSave).subscribe();
+    }
     let cacheFileName = `${fileContext.model.fileName}:${fileContext.model.path}`;
     if (cacheFileName) {
       this.log.debug(`Clearing cache for`,cacheFileName);

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -231,7 +231,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
 
   //almost like selectfilehandler, except altering the list of opened files
   public openFileHandler(fileContext: ProjectContext) {
-    if(+window.localStorage.getItem("activeZluxEditors") < 2){
+    if(+window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0] < 2){
       this.saveFilePathSessionRestore(fileContext);
     }
     for (const file of this._openFileList.getValue()) {
@@ -251,7 +251,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   }
 
   public closeFileHandler(fileContext: ProjectContext) {
-    if(+window.localStorage.getItem("activeZluxEditors") < 2){
+    if(+window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0] < 2){
       this.openFilesAndDatasets.splice(this.openFilesAndDatasets.indexOf(fileContext.model.path+"/"+fileContext.name), 1);
       this.dataToSave = {"files":this.openFilesAndDatasets}
       this.HTTP.put(ZoweZLUX.uriBroker.pluginConfigUri(this.plugin,this.filePath,this.fileNameToSave), this.dataToSave).subscribe();

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -102,6 +102,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   private fileNameToSave : string = 'fileList'
   private dataToSave : {files:string[]}
   private openFilesAndDatasets : Array<string> = [];
+  public numberOfTabsToRestore : number = 0;
   constructor(
     private utils: UtilsService,
     private http: HttpService,
@@ -231,7 +232,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
 
   //almost like selectfilehandler, except altering the list of opened files
   public openFileHandler(fileContext: ProjectContext) {
-    if(+window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0] < 2){
+    if(+window.localStorage.getItem("org.zowe.editor-openWindows").split(":")[0] < 2 && this.numberOfTabsToRestore == 0){
       this.updateSavedTabsStorage(fileContext);
     }
     for (const file of this._openFileList.getValue()) {


### PR DESCRIPTION
This PR serves as a feature enhancement for Zlux Editor - Restore last openend files/datasets in Editor on next launch
- [x] Save file path on file/dataset open
- [x] Delete file path on file/dataset close
- [x] Restore last opened files/datasets on next launch

Dependent-on: https://github.com/zowe/zlux-app-manager/pull/274

Signed-off-by: Mitesh Goplani mgoplani@rocketsoftware.com