### PR TITLE
Reduce package size by removing almost certainly unused web assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `2.2.1`
+
+- Removed .map files and large uncompressed files with .gz compressed variants, in order to reduce package size.
+
 ## `2.2.0`
 
 - Removed use of node-sass, so that native compilation is not required

--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.zowe.editor",
   "apiVersion": "1.0.0",
-  "pluginVersion": "2.2.0",
+  "pluginVersion": "2.2.1",
   "license": "EPL-2.0",
   "author": "Zowe",
   "homepage": "https://github.com/zowe/zlux-editor",

--- a/webClient/package-lock.json
+++ b/webClient/package-lock.json
@@ -5,22 +5,22 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "0.803.27",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/architect/-/architect-0.803.27.tgz",
-      "integrity": "sha1-y0DMlob4Dq8tOu1kxBqy6hg0S7o=",
+      "version": "0.803.29",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/architect/-/architect-0.803.29.tgz",
+      "integrity": "sha1-A5mWkIesd4drjkKcsm7r0gWWYHs=",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "8.3.27",
+        "@angular-devkit/core": "8.3.29",
         "rxjs": "6.4.0"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "8.3.27",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/core/-/core-8.3.27.tgz",
-          "integrity": "sha1-2Z55e7DIvmQ/AccH/bOQSrNHsQY=",
+          "version": "8.3.29",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/core/-/core-8.3.29.tgz",
+          "integrity": "sha1-NHft1kWGU/g+bXhoSxAMG++BOC8=",
           "dev": true,
           "requires": {
-            "ajv": "6.10.2",
+            "ajv": "6.12.3",
             "fast-json-stable-stringify": "2.0.0",
             "magic-string": "0.25.3",
             "rxjs": "6.4.0",
@@ -39,26 +39,26 @@
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "0.803.27",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/build-angular/-/build-angular-0.803.27.tgz",
-      "integrity": "sha1-s+d4Pa7hlAqvRrFRHBhtPpkulSk=",
+      "version": "0.803.29",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/build-angular/-/build-angular-0.803.29.tgz",
+      "integrity": "sha1-TMLst8TKSDifBdHgXUcI+CyMd2c=",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.803.27",
-        "@angular-devkit/build-optimizer": "0.803.27",
-        "@angular-devkit/build-webpack": "0.803.27",
-        "@angular-devkit/core": "8.3.27",
+        "@angular-devkit/architect": "0.803.29",
+        "@angular-devkit/build-optimizer": "0.803.29",
+        "@angular-devkit/build-webpack": "0.803.29",
+        "@angular-devkit/core": "8.3.29",
         "@babel/core": "7.8.7",
         "@babel/preset-env": "7.8.7",
-        "@ngtools/webpack": "8.3.27",
-        "ajv": "6.10.2",
+        "@ngtools/webpack": "8.3.29",
+        "ajv": "6.12.3",
         "autoprefixer": "9.6.1",
         "browserslist": "4.10.0",
         "cacache": "12.0.2",
         "caniuse-lite": "1.0.30001035",
         "circular-dependency-plugin": "5.2.0",
         "clean-css": "4.2.1",
-        "copy-webpack-plugin": "6.0.2",
+        "copy-webpack-plugin": "6.0.3",
         "core-js": "3.6.4",
         "coverage-istanbul-loader": "2.0.3",
         "file-loader": "4.2.0",
@@ -91,7 +91,7 @@
         "stylus": "0.54.5",
         "stylus-loader": "3.0.2",
         "terser": "4.6.3",
-        "terser-webpack-plugin": "1.4.3",
+        "terser-webpack-plugin": "3.0.3",
         "tree-kill": "1.2.2",
         "webpack": "4.39.2",
         "webpack-dev-middleware": "3.7.2",
@@ -103,12 +103,12 @@
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "8.3.27",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/core/-/core-8.3.27.tgz",
-          "integrity": "sha1-2Z55e7DIvmQ/AccH/bOQSrNHsQY=",
+          "version": "8.3.29",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/core/-/core-8.3.29.tgz",
+          "integrity": "sha1-NHft1kWGU/g+bXhoSxAMG++BOC8=",
           "dev": true,
           "requires": {
-            "ajv": "6.10.2",
+            "ajv": "6.12.3",
             "fast-json-stable-stringify": "2.0.0",
             "magic-string": "0.25.3",
             "rxjs": "6.4.0",
@@ -151,28 +151,28 @@
           "dev": true
         },
         "copy-webpack-plugin": {
-          "version": "6.0.2",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/copy-webpack-plugin/-/copy-webpack-plugin-6.0.2.tgz",
-          "integrity": "sha1-EO/GrSGaYay/L1+1Cvg9o4QxvDQ=",
+          "version": "6.0.3",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/copy-webpack-plugin/-/copy-webpack-plugin-6.0.3.tgz",
+          "integrity": "sha1-Kz0r/GhhuWQypl8BSXIK29kCBAs=",
           "dev": true,
           "requires": {
             "cacache": "^15.0.4",
-            "fast-glob": "^3.2.2",
+            "fast-glob": "^3.2.4",
             "find-cache-dir": "^3.3.1",
             "glob-parent": "^5.1.1",
             "globby": "^11.0.1",
             "loader-utils": "^2.0.0",
             "normalize-path": "^3.0.0",
-            "p-limit": "^2.3.0",
+            "p-limit": "^3.0.1",
             "schema-utils": "^2.7.0",
-            "serialize-javascript": "^3.1.0",
+            "serialize-javascript": "^4.0.0",
             "webpack-sources": "^1.4.3"
           },
           "dependencies": {
             "cacache": {
-              "version": "15.0.4",
-              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacache/-/cacache-15.0.4.tgz",
-              "integrity": "sha1-ssI89KxPXq0AT7FaDvsKIDQHQfE=",
+              "version": "15.0.5",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacache/-/cacache-15.0.5.tgz",
+              "integrity": "sha1-aRYoM9opFw1nMjNGQ8YOAF9fF9A=",
               "dev": true,
               "requires": {
                 "@npmcli/move-file": "^1.0.1",
@@ -180,7 +180,7 @@
                 "fs-minipass": "^2.0.0",
                 "glob": "^7.1.4",
                 "infer-owner": "^1.0.4",
-                "lru-cache": "^5.1.1",
+                "lru-cache": "^6.0.0",
                 "minipass": "^3.1.1",
                 "minipass-collect": "^1.0.2",
                 "minipass-flush": "^1.0.5",
@@ -292,6 +292,15 @@
             "minimist": "^1.2.5"
           }
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/micromatch/-/micromatch-3.1.10.tgz",
@@ -320,19 +329,13 @@
           "dev": true
         },
         "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+          "version": "3.0.2",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha1-FmTgEK88rcaBuq/T4qQ3vnsPtf4=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-          "dev": true
         },
         "rimraf": {
           "version": "3.0.2",
@@ -442,6 +445,27 @@
             "webpack-sources": "^1.4.1"
           },
           "dependencies": {
+            "find-cache-dir": {
+              "version": "2.1.0",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+              "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+              "dev": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
+              }
+            },
+            "make-dir": {
+              "version": "2.1.0",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-2.1.0.tgz",
+              "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+              "dev": true,
+              "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+              }
+            },
             "mkdirp": {
               "version": "0.5.5",
               "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -449,6 +473,15 @@
               "dev": true,
               "requires": {
                 "minimist": "^1.2.5"
+              }
+            },
+            "pkg-dir": {
+              "version": "3.0.0",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-3.0.0.tgz",
+              "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+              "dev": true,
+              "requires": {
+                "find-up": "^3.0.0"
               }
             },
             "schema-utils": {
@@ -461,15 +494,59 @@
                 "ajv-errors": "^1.0.0",
                 "ajv-keywords": "^3.1.0"
               }
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+              "dev": true
+            },
+            "serialize-javascript": {
+              "version": "3.1.0",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+              "integrity": "sha1-i/OpFwcSZk7yVhtEtpHq/jmSFOo=",
+              "dev": true,
+              "requires": {
+                "randombytes": "^2.1.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+              "dev": true
+            },
+            "terser-webpack-plugin": {
+              "version": "1.4.4",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
+              "integrity": "sha1-LGNUQ0cyS6r6mla6rd8WNMir/C8=",
+              "dev": true,
+              "requires": {
+                "cacache": "^12.0.2",
+                "find-cache-dir": "^2.1.0",
+                "is-wsl": "^1.1.0",
+                "schema-utils": "^1.0.0",
+                "serialize-javascript": "^3.1.0",
+                "source-map": "^0.6.1",
+                "terser": "^4.1.2",
+                "webpack-sources": "^1.4.0",
+                "worker-farm": "^1.7.0"
+              }
             }
           }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+          "dev": true
         }
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.803.27",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/build-optimizer/-/build-optimizer-0.803.27.tgz",
-      "integrity": "sha1-Zhgl1VxeU1VInw57zt3yLtZmqZI=",
+      "version": "0.803.29",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/build-optimizer/-/build-optimizer-0.803.29.tgz",
+      "integrity": "sha1-kcAz5qszE9M47Jw9TEDWTOGzJLw=",
       "dev": true,
       "requires": {
         "loader-utils": "1.2.3",
@@ -494,23 +571,23 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.803.27",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/build-webpack/-/build-webpack-0.803.27.tgz",
-      "integrity": "sha1-kDt96SpFZ4hzSeSL1ryp8MvFVxo=",
+      "version": "0.803.29",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/build-webpack/-/build-webpack-0.803.29.tgz",
+      "integrity": "sha1-zq7mWPC3Gg/uTxC1dLSeGS0zOnw=",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.803.27",
-        "@angular-devkit/core": "8.3.27",
+        "@angular-devkit/architect": "0.803.29",
+        "@angular-devkit/core": "8.3.29",
         "rxjs": "6.4.0"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "8.3.27",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/core/-/core-8.3.27.tgz",
-          "integrity": "sha1-2Z55e7DIvmQ/AccH/bOQSrNHsQY=",
+          "version": "8.3.29",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/core/-/core-8.3.29.tgz",
+          "integrity": "sha1-NHft1kWGU/g+bXhoSxAMG++BOC8=",
           "dev": true,
           "requires": {
-            "ajv": "6.10.2",
+            "ajv": "6.12.3",
             "fast-json-stable-stringify": "2.0.0",
             "magic-string": "0.25.3",
             "rxjs": "6.4.0",
@@ -1457,18 +1534,18 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/code-frame/-/code-frame-7.10.1.tgz",
-      "integrity": "sha1-1UgcUJXaocV+FuVMb5GYRDr7Sf8=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha1-Fo2ho26Q2miujUnA8bSMfGJJITo=",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.1"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/compat-data": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/compat-data/-/compat-data-7.10.1.tgz",
-      "integrity": "sha1-sQhf/nLNF78sDueQ/An5YmARsts=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/compat-data/-/compat-data-7.10.5.tgz",
+      "integrity": "sha1-04Ql5n6paxSAo/UEBNG/hWdjAaY=",
       "dev": true,
       "requires": {
         "browserslist": "^4.12.0",
@@ -1477,21 +1554,21 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.12.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserslist/-/browserslist-4.12.0.tgz",
-          "integrity": "sha1-BsbVcVoe3mxR/Dn/Z/1kf3QLZW0=",
+          "version": "4.13.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserslist/-/browserslist-4.13.0.tgz",
+          "integrity": "sha1-QlVsugEeGwondbYRy6ao7KGOlA0=",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001043",
-            "electron-to-chromium": "^1.3.413",
-            "node-releases": "^1.1.53",
-            "pkg-up": "^2.0.0"
+            "caniuse-lite": "^1.0.30001093",
+            "electron-to-chromium": "^1.3.488",
+            "escalade": "^3.0.1",
+            "node-releases": "^1.1.58"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001083",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/caniuse-lite/-/caniuse-lite-1.0.30001083.tgz",
-          "integrity": "sha1-UkEMIMbwKfYE8NReygQ5qC5xJEI=",
+          "version": "1.0.30001107",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/caniuse-lite/-/caniuse-lite-1.0.30001107.tgz",
+          "integrity": "sha1-gJNg33pbNFj2J6pGsPbtbVI52po=",
           "dev": true
         },
         "semver": {
@@ -1549,14 +1626,13 @@
       }
     },
     "@babel/generator": {
-      "version": "7.10.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/generator/-/generator-7.10.2.tgz",
-      "integrity": "sha1-D6W1sjiduL/fzDSStVHuIPXdaak=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/generator/-/generator-7.10.5.tgz",
+      "integrity": "sha1-G5A1VLyMWD7o0l8eiWlzLmuCmmk=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.2",
+        "@babel/types": "^7.10.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -1569,31 +1645,31 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.1.tgz",
-      "integrity": "sha1-9tCKzG9wu9WbQ2JiVT+y4lmhomg=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+      "integrity": "sha1-W/DUlaP3V6w72ki1vzs7ownHK6M=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.1.tgz",
-      "integrity": "sha1-DsfZvoF0k0UyZh+HeD6xjXIpAFk=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+      "integrity": "sha1-uwt18xv5jL+f8UPBrleLhydK4aM=",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/helper-explode-assignable-expression": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.10.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.2.tgz",
-      "integrity": "sha1-oX2XI7bix1ApnSoU1GN8dpNtgoU=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
+      "integrity": "sha1-gEro4/BDdmB8x5G51H1UAnYzK9I=",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.10.1",
+        "@babel/compat-data": "^7.10.4",
         "browserslist": "^4.12.0",
         "invariant": "^2.2.4",
         "levenary": "^1.1.1",
@@ -1601,21 +1677,21 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.12.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserslist/-/browserslist-4.12.0.tgz",
-          "integrity": "sha1-BsbVcVoe3mxR/Dn/Z/1kf3QLZW0=",
+          "version": "4.13.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserslist/-/browserslist-4.13.0.tgz",
+          "integrity": "sha1-QlVsugEeGwondbYRy6ao7KGOlA0=",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001043",
-            "electron-to-chromium": "^1.3.413",
-            "node-releases": "^1.1.53",
-            "pkg-up": "^2.0.0"
+            "caniuse-lite": "^1.0.30001093",
+            "electron-to-chromium": "^1.3.488",
+            "escalade": "^3.0.1",
+            "node-releases": "^1.1.58"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001083",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/caniuse-lite/-/caniuse-lite-1.0.30001083.tgz",
-          "integrity": "sha1-UkEMIMbwKfYE8NReygQ5qC5xJEI=",
+          "version": "1.0.30001107",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/caniuse-lite/-/caniuse-lite-1.0.30001107.tgz",
+          "integrity": "sha1-gJNg33pbNFj2J6pGsPbtbVI52po=",
           "dev": true
         },
         "semver": {
@@ -1627,293 +1703,293 @@
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.1.tgz",
-      "integrity": "sha1-G4/uqxWUy8+/OrWju8q6wEaO/b0=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
+      "integrity": "sha1-/dYNiFJGWaC2lZwFeZJeQlcU87g=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.1",
-        "@babel/helper-regex": "^7.10.1",
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-regex": "^7.10.4",
         "regexpu-core": "^4.7.0"
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-define-map/-/helper-define-map-7.10.1.tgz",
-      "integrity": "sha1-XmnugwhkhHDdeQDRWcBEwQKFIh0=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+      "integrity": "sha1-tTwQ23imQIABUmkrEzkxR6y5uzA=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.10.1",
-        "@babel/types": "^7.10.1",
-        "lodash": "^4.17.13"
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/types": "^7.10.5",
+        "lodash": "^4.17.19"
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.1.tgz",
-      "integrity": "sha1-6ddjBe4RYspGc1euJd+U8XmvK34=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
+      "integrity": "sha1-QKHNkXv/Eoj2malKdbN6Gi29jHw=",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
-      "integrity": "sha1-kr1jgpv8khWsqdne+oX1a1OUVPQ=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha1-0tOyDFmtjEcRL6fSqUvAnV74Lxo=",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.10.1",
-        "@babel/template": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
-      "integrity": "sha1-cwM5CoG6fLWWE4laGSuThQ43P30=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha1-mMHL6g4jMvM/mkZhuM4VBbLBm6I=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.1.tgz",
-      "integrity": "sha1-fnfILl3K4evxIxdMOFqq2/eH0Hc=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+      "integrity": "sha1-1JsAHR1aaMpeZgTdoBpil/fJOB4=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
-      "integrity": "sha1-Qyln/X4SpK/vZsRofUyiK8BFbxU=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+      "integrity": "sha1-Fy9W56Y+eBEvOgQFXyQ2WvcC5+4=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.5"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
-      "integrity": "sha1-3TMb1FvMxWbOdwBOnQX+F63ROHY=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+      "integrity": "sha1-TFxUvgS9MWcKc4J5fXW5+i5bViA=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
-      "integrity": "sha1-JOLwjuaDLGCxV7sJNshr73IQxiI=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+      "integrity": "sha1-EgwnHAszU2c/zf2MBT2zxUSiYNY=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.10.1",
-        "@babel/helper-replace-supers": "^7.10.1",
-        "@babel/helper-simple-access": "^7.10.1",
-        "@babel/helper-split-export-declaration": "^7.10.1",
-        "@babel/template": "^7.10.1",
-        "@babel/types": "^7.10.1",
-        "lodash": "^4.17.13"
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.5",
+        "lodash": "^4.17.19"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
-      "integrity": "sha1-tKHyVhhwzhJHzt2wKjhg+pbXJUM=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+      "integrity": "sha1-UNyWQT1ZT5lad5BZBbBYk813lnM=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-      "integrity": "sha1-7Fpc8O7JJbZsYFgDKLEiwBIwoSc=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha1-L3WoMSadT2d95JmG3/WZJ1M883U=",
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-regex/-/helper-regex-7.10.1.tgz",
-      "integrity": "sha1-Ahzxp7qZgi+ZMiKgAcw/7IMlW5Y=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+      "integrity": "sha1-Mt+7eYmQc8QVVXBToZvQVarlCuA=",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.19"
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.1.tgz",
-      "integrity": "sha1-utaqpP85zo1Lgsyq4L/g99u19DI=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
+      "integrity": "sha1-/Oi+pOlpC76SMFbe0h5UtOi2jtU=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.1",
-        "@babel/helper-wrap-function": "^7.10.1",
-        "@babel/template": "^7.10.1",
-        "@babel/traverse": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-wrap-function": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
-      "integrity": "sha1-7GhZ0gxdgIf2otxOAU23Iol18T0=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+      "integrity": "sha1-1YXNk4jqBuYDHkzUS2cTy+rZ5s8=",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.10.1",
-        "@babel/helper-optimise-call-expression": "^7.10.1",
-        "@babel/traverse": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
-      "integrity": "sha1-CPt+Iqzp64Mm9+OSChwgUvE9hR4=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+      "integrity": "sha1-D1zNopRSd6KnotOoIeFTle3PNGE=",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
-      "integrity": "sha1-xvS+HLwV46ho5MZKF9XTHXVNo18=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+      "integrity": "sha1-LHBXbqo7VgmyTLmdsoiMw/xCUdE=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-      "integrity": "sha1-V3CwwagmxPU/Xt5eFTFj4DGOlLU=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha1-p4x6clHgH2FlEtMbEK3PUq2l4NI=",
       "dev": true
     },
     "@babel/helper-wrap-function": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-wrap-function/-/helper-wrap-function-7.10.1.tgz",
-      "integrity": "sha1-lW0TENZpYlenr9R+TELf2l387ck=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
+      "integrity": "sha1-im9wHqsP8592W1oc/vQJmQ5iS4c=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.10.1",
-        "@babel/template": "^7.10.1",
-        "@babel/traverse": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helpers": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helpers/-/helpers-7.10.1.tgz",
-      "integrity": "sha1-poJ7fLl1ydnO9f1h2Rn2DYhEqXM=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/helpers/-/helpers-7.10.4.tgz",
+      "integrity": "sha1-Kr6w1yGv98Cpc3a54fb2XXpHUEQ=",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.10.1",
-        "@babel/traverse": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/highlight": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/highlight/-/highlight-7.10.1.tgz",
-      "integrity": "sha1-hB0Ji6YTuhpCeis4PXnjVVLDiuA=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha1-fRvf1ldTU4+r5sOFls23bZrGAUM=",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.1",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.10.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/parser/-/parser-7.10.2.tgz",
-      "integrity": "sha1-hxgH8QRCuS/5fkeDubVPagyoEtA=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/parser/-/parser-7.10.5.tgz",
+      "integrity": "sha1-58a/Wn3v+VfOyfBLVR4nYpCdgms=",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.1.tgz",
-      "integrity": "sha1-aRGvW6LmFcT/PEl/4vR7Nb9tflU=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+      "integrity": "sha1-NJHKvy98F5q4IGBs7Cf+0V4OhVg=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
-        "@babel/helper-remap-async-to-generator": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.10.4",
         "@babel/plugin-syntax-async-generators": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.1.tgz",
-      "integrity": "sha1-42l53B3Dtz9taBb8SVHaI2NIjvA=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
+      "integrity": "sha1-uleibLmLN3QenVvKG4sN34KR8X4=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-dynamic-import": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.1.tgz",
-      "integrity": "sha1-seaR7iTGUbWl4yITIisjeXNK/wk=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
+      "integrity": "sha1-WT5ZxjUoFgIzvTIbGuvgggwjQds=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-json-strings": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.1.tgz",
-      "integrity": "sha1-AtyiFnOEL/L+djrCU3d/I16bv3g=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
+      "integrity": "sha1-AqfpYfwy5tWy2wZJ4Bv4Dd7n4Eo=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.1.tgz",
-      "integrity": "sha1-y6RJCKyfFCZQtKZbiqBr80eNX7Y=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
+      "integrity": "sha1-UBKawha5pqVbOFP92SPnS/VTpMA=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-transform-parameters": "^7.10.1"
+        "@babel/plugin-transform-parameters": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.1.tgz",
-      "integrity": "sha1-yfhtmTBfn6UxtWj/WrjJZLiyI9I=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
+      "integrity": "sha1-Mck4MJ0kp4pJ1o/av/qoY3WFVN0=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.1.tgz",
-      "integrity": "sha1-FfXW0icIYpRRqRvij4+sxVsOgYw=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.4.tgz",
+      "integrity": "sha1-dQ8SVekwofgtjN3kUDH4Gg0K3/c=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-optional-chaining": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.1.tgz",
-      "integrity": "sha1-3AT+sl4t1wwSsF1oAZDhOPosDG8=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
+      "integrity": "sha1-RIPNpTBBzjQTt/4vAAImZd36p10=",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -1980,318 +2056,317 @@
       }
     },
     "@babel/plugin-syntax-top-level-await": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.1.tgz",
-      "integrity": "sha1-i4cz+MVzl7PqpH3bqIQVhtyu82I=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
+      "integrity": "sha1-S764kXtU/PdoNk4KgfVg4zo+9X0=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.1.tgz",
-      "integrity": "sha1-y17jo28IY8BurQtAm0zEOoibKVs=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
+      "integrity": "sha1-4ilg135pfHT0HFAdRNc9v4pqZM0=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.1.tgz",
-      "integrity": "sha1-5RU+saPgKPeRlO2Kekv1X4YrIGI=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
+      "integrity": "sha1-QaUBfknrbzzak5KlHu8pQFskWjc=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1",
-        "@babel/helper-remap-async-to-generator": "^7.10.1"
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.10.4"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.1.tgz",
-      "integrity": "sha1-FGhW51bVSyD/8UuBlFaz4BgguF0=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
+      "integrity": "sha1-GvpZV0T3XkOpGvc7DZmOz+Trwug=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.1.tgz",
-      "integrity": "sha1-Rwktico0WBFFHNDcXZFgWYJwXV4=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz",
+      "integrity": "sha1-uBuKr++/5o8PZffvOXuezmimA30=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
-        "lodash": "^4.17.13"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.1.tgz",
-      "integrity": "sha1-bhHdbE365w9UBICkcCR37XZtcz8=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
+      "integrity": "sha1-QFE2rys+IYvEoZJiKLyRerGgrcc=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.1",
-        "@babel/helper-define-map": "^7.10.1",
-        "@babel/helper-function-name": "^7.10.1",
-        "@babel/helper-optimise-call-expression": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1",
-        "@babel/helper-replace-supers": "^7.10.1",
-        "@babel/helper-split-export-declaration": "^7.10.1",
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-define-map": "^7.10.4",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
         "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.1.tgz",
-      "integrity": "sha1-Wao5kGRCnWTc5c9275uQtyRevQc=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
+      "integrity": "sha1-ne2DqBboLe0o1S1LTsvdgQzfwOs=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.1.tgz",
-      "integrity": "sha1-q9WOUTN4Fco6IqM2uF9iuZjnGQc=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
+      "integrity": "sha1-cN3Ss9G+qD0BUJ6bsl3bOnT8heU=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.1.tgz",
-      "integrity": "sha1-kguf7C14u1frtkpkTVwrpnzBBO4=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
+      "integrity": "sha1-RpwgYhBcHragQOr0+sS0iAeDle4=",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.1.tgz",
-      "integrity": "sha1-yQCnk76wlrydTQqdDN4ZUY/8g7k=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
+      "integrity": "sha1-aX5Qyf7hQ4D+hD0fMGspVhdDHkc=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.1.tgz",
-      "integrity": "sha1-J5wxFnVqYN1ub15Ii6eVfbnFnrM=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
+      "integrity": "sha1-WuM4xX+M9AAb2zVgeuZrktZlry4=",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.1.tgz",
-      "integrity": "sha1-/wERl4TrDuMiWOhkYVe6JQH8/aU=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
+      "integrity": "sha1-wIiS6IGdOl2ykDGxFa9RHbv+uuk=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.1.tgz",
-      "integrity": "sha1-TtRv1uHY/eKi7HsDxm2FPSySQn0=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
+      "integrity": "sha1-akZ4gOD8ljhRS6NpERgR3b4mRLc=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.1.tgz",
-      "integrity": "sha1-V5T42oKEayLk5mMeoWWLznCOtGo=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
+      "integrity": "sha1-n0K6CEEQChNfInEtDjkcRi9XHzw=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.1.tgz",
-      "integrity": "sha1-kDR8ujG8pvOUs/e9ldK7/Z/OLzk=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
+      "integrity": "sha1-sexE/PGVr8uNssYs2OVRyIG6+Lc=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.1.tgz",
-      "integrity": "sha1-ZZUOjgV5fr0v5TK5bhn8VIKh1So=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+      "integrity": "sha1-G5zdrwXZ6Is6rTOcs+RFxPAgqbE=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.1.tgz",
-      "integrity": "sha1-1f9LRBPtl//e2ZlhBW4fuYD7kwE=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
+      "integrity": "sha1-ZmZ8Pu2h6/eJbUHx8WsXEFovvKA=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1",
-        "@babel/helper-simple-access": "^7.10.1",
+        "@babel/helper-module-transforms": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.1.tgz",
-      "integrity": "sha1-mWLksKxqry4gQxraPY7HIILL/7Y=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
+      "integrity": "sha1-YnAJnIVAZmgbrp4F+H4bnK2+jIU=",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.10.1",
-        "@babel/helper-module-transforms": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-hoist-variables": "^7.10.4",
+        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.1.tgz",
-      "integrity": "sha1-6ggJEf/G6yGEClGXo57eTuZ7FZU=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
+      "integrity": "sha1-moSB/oG4JGVLOgtl2j34nz0hg54=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-module-transforms": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.8.3",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
-      "integrity": "sha1-oqcr/6ICrA4tBQav0JOcXsvEjGw=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
+      "integrity": "sha1-eLTZeIELbzvPA/njGPL8DtQa7LY=",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3"
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.1.tgz",
-      "integrity": "sha1-buQaXmSNp2MuIrb7VAEuh/YS8yQ=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
+      "integrity": "sha1-kJfXU8t7Aky3OBo7LlLpUTqcaIg=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.1.tgz",
-      "integrity": "sha1-LjAWsK2/JimDvw1RIdZ2pe2cT94=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
+      "integrity": "sha1-1xRsTROUM+emUm+IjGZ+MUoJOJQ=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
-        "@babel/helper-replace-supers": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.1.tgz",
-      "integrity": "sha1-slk4o8X64DVBRKcgsHsydm9oPd0=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+      "integrity": "sha1-WdM51Y0LGVBDX0BD504lEABeLEo=",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-property-literals": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.1.tgz",
-      "integrity": "sha1-z/xzFSGSMO2B3FPkYlv4aBW2BQ0=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
+      "integrity": "sha1-9v5UtlkDUimHhbg+3YFdIUxC48A=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.1.tgz",
-      "integrity": "sha1-EOF1y+e9tjzJs5+bP4I8XHxcVJA=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
+      "integrity": "sha1-IBXlnYOQdOdoON4hWdtCGWb9i2M=",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.14.2"
       }
     },
     "@babel/plugin-transform-reserved-words": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.1.tgz",
-      "integrity": "sha1-D8ECcxK00cMnaleJDIrjvMC2SoY=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
+      "integrity": "sha1-jyaCvNzvntMn4bCGFYXXAT+KVN0=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.1.tgz",
-      "integrity": "sha1-6LVPI4ocy65ILE3OlGGArnsxQ/M=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
+      "integrity": "sha1-n9Jexc3VVbt/Rz5ebuHJce7eTdY=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.1.tgz",
-      "integrity": "sha1-DG1higxEYaJ0QYRgooycz1I5p8g=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.4.tgz",
+      "integrity": "sha1-TiyF6g1quu4bJNz7uuQm/o1nTP8=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.1.tgz",
-      "integrity": "sha1-kPyJt1JiKL7ZhCz/NYgnCno5OwA=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
+      "integrity": "sha1-jziJ7oZXWBEwop2cyR18c7fEoo0=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
-        "@babel/helper-regex": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-regex": "^7.10.4"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.1.tgz",
-      "integrity": "sha1-kUx7f0dSxXDqAFU7QoTa2AcOhig=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+      "integrity": "sha1-eLxdYmpmQtszEtnQ8AH152Of3ow=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.1.tgz",
-      "integrity": "sha1-YMAjm2mWXRZrgKhN5zFcG8fguw4=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
+      "integrity": "sha1-lQnxp+7DHE7b/+E3wWzDP/C8W/w=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.1.tgz",
-      "integrity": "sha1-a1jyrqe2jfN6xQJdnIh1JEOmtD8=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
+      "integrity": "sha1-5W1x+SgvrG2wnIJ0IFVXbV5tgKg=",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/preset-env": {
@@ -2368,58 +2443,58 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.10.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/runtime/-/runtime-7.10.2.tgz",
-      "integrity": "sha1-0QPyHyYCSX04NIoy4AhjfVBtuDk=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/runtime/-/runtime-7.10.5.tgz",
+      "integrity": "sha1-MD2L1EDs1aSR6uYRf9M2dphnTFw=",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha1-2Hih0JS0MG0QuQlkhLM+vVXiZpc=",
+          "version": "0.13.7",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U=",
           "dev": true
         }
       }
     },
     "@babel/template": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/template/-/template-7.10.1.tgz",
-      "integrity": "sha1-4WcVSpTLXxSyjcWPU1bSFi9TmBE=",
+      "version": "7.10.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/template/-/template-7.10.4.tgz",
+      "integrity": "sha1-MlGZbEIA68cdGo/EBfupQPNrong=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.1",
-        "@babel/parser": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.10.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/traverse/-/traverse-7.10.1.tgz",
-      "integrity": "sha1-u87zAx5BUqbAtQFH9JWN9Uyg3Sc=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/traverse/-/traverse-7.10.5.tgz",
+      "integrity": "sha1-d85GT1sli+Jlr2GNj93wU28gtWQ=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.1",
-        "@babel/generator": "^7.10.1",
-        "@babel/helper-function-name": "^7.10.1",
-        "@babel/helper-split-export-declaration": "^7.10.1",
-        "@babel/parser": "^7.10.1",
-        "@babel/types": "^7.10.1",
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.10.5",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/parser": "^7.10.5",
+        "@babel/types": "^7.10.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.19"
       }
     },
     "@babel/types": {
-      "version": "7.10.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/types/-/types-7.10.2.tgz",
-      "integrity": "sha1-MCg74xytDb9vsAvUBkHKDqZ1Fy0=",
+      "version": "7.10.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@babel/types/-/types-7.10.5.tgz",
+      "integrity": "sha1-2Irn4v3oa/v+hR1Nga+nCpl7XRU=",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.1",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -2430,12 +2505,12 @@
       "dev": true
     },
     "@ngtools/webpack": {
-      "version": "8.3.27",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@ngtools/webpack/-/webpack-8.3.27.tgz",
-      "integrity": "sha1-8uhBvYf7CPuZ+E+3hN3rV7HhSNQ=",
+      "version": "8.3.29",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@ngtools/webpack/-/webpack-8.3.29.tgz",
+      "integrity": "sha1-e2mEzczWM91ofpQTqJotnhNg92w=",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "8.3.27",
+        "@angular-devkit/core": "8.3.29",
         "enhanced-resolve": "4.1.0",
         "rxjs": "6.4.0",
         "tree-kill": "1.2.2",
@@ -2443,12 +2518,12 @@
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "8.3.27",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/core/-/core-8.3.27.tgz",
-          "integrity": "sha1-2Z55e7DIvmQ/AccH/bOQSrNHsQY=",
+          "version": "8.3.29",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular-devkit/core/-/core-8.3.29.tgz",
+          "integrity": "sha1-NHft1kWGU/g+bXhoSxAMG++BOC8=",
           "dev": true,
           "requires": {
-            "ajv": "6.10.2",
+            "ajv": "6.12.3",
             "fast-json-stable-stringify": "2.0.0",
             "magic-string": "0.25.3",
             "rxjs": "6.4.0",
@@ -2551,9 +2626,9 @@
       }
     },
     "@types/glob": {
-      "version": "7.1.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-BsomUhNTpUXZSgrcdPOKWdIyyYc=",
+      "version": "7.1.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha1-5rqA82t9qtLGhazZJmOC5omFwYM=",
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
@@ -2567,9 +2642,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.155",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/lodash/-/lodash-4.14.155.tgz",
-      "integrity": "sha1-4rRRT0aiYf0RVC5HUZwg6857wjo="
+      "version": "4.14.158",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/lodash/-/lodash-4.14.158.tgz",
+      "integrity": "sha1-s46otv55ms0HbXqNerccJu9394U="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -2904,12 +2979,12 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
+      "version": "6.12.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-6.12.3.tgz",
+      "integrity": "sha1-GMWvOKER3etPJpe9eNaKvByr1wY=",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -2922,9 +2997,9 @@
       "dev": true
     },
     "ajv-keywords": {
-      "version": "3.4.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha1-75FuJxxkrBIXH9g4TqrmsjRYVNo=",
+      "version": "3.5.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
       "dev": true
     },
     "amdefine": {
@@ -3396,9 +3471,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
+      "version": "2.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk=",
       "dev": true
     },
     "bluebird": {
@@ -3609,60 +3684,6 @@
         "electron-to-chromium": "^1.3.378",
         "node-releases": "^1.1.52",
         "pkg-up": "^3.1.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-          "dev": true
-        },
-        "pkg-up": {
-          "version": "3.1.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-up/-/pkg-up-3.1.0.tgz",
-          "integrity": "sha1-EA7CNcwVDk/UJRlBJZaihRKg3vU=",
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0"
-          }
-        }
       }
     },
     "buffer": {
@@ -3840,9 +3861,9 @@
       }
     },
     "chokidar": {
-      "version": "3.4.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chokidar/-/chokidar-3.4.0.tgz",
-      "integrity": "sha1-swYRQjzjdjV8dlubj5BLn7o8C+g=",
+      "version": "3.4.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chokidar/-/chokidar-3.4.1.tgz",
+      "integrity": "sha1-6QW97PEOqgoLHbDGZEgcxMvCK6E=",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -4360,15 +4381,6 @@
             "pkg-dir": "^3.0.0"
           }
         },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -4418,16 +4430,6 @@
           "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
           "dev": true
         },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
         "make-dir": {
           "version": "2.1.0",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-2.1.0.tgz",
@@ -4437,30 +4439,6 @@
             "pify": "^4.0.1",
             "semver": "^5.6.0"
           }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-          "dev": true
         },
         "path-type": {
           "version": "3.0.0",
@@ -4711,14 +4689,13 @@
       "dev": true
     },
     "css-selector-tokenizer": {
-      "version": "0.7.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/css-selector-tokenizer/-/css-selector-tokenizer-0.7.2.tgz",
-      "integrity": "sha1-EeXifJpI2QKE8i1FBhwwPXolrYc=",
+      "version": "0.7.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
+      "integrity": "sha1-c18mGG5nx0mq8nV4NAXPBmH66PE=",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2",
-        "regexpu-core": "^4.6.0"
+        "fastparse": "^1.1.2"
       }
     },
     "cssauron": {
@@ -5040,15 +5017,15 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.473",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/electron-to-chromium/-/electron-to-chromium-1.3.473.tgz",
-      "integrity": "sha1-0M1f45EEb7cGdOyYFJ8Pl2CdKbg=",
+      "version": "1.3.509",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/electron-to-chromium/-/electron-to-chromium-1.3.509.tgz",
+      "integrity": "sha1-gw/Lic1m3CmE0Y15SXO5nj8AWEw=",
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha1-BcVnjXFzwEnYykM1UiJKSV0ON2I=",
+      "version": "6.5.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -5087,12 +5064,23 @@
       "dev": true
     },
     "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "version": "0.1.13",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha1-VldK/deR9UqOmyeFwFgqLSYhD6k=",
       "dev": true,
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha1-zhPRh1sMOmdL1qBLf3awGxtt7QE=",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "end-of-stream": {
@@ -5194,6 +5182,12 @@
         "through": "~2.3.6"
       }
     },
+    "escalade": {
+      "version": "3.0.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/escalade/-/escalade-3.0.2.tgz",
+      "integrity": "sha1-algNcO24eIDyK0yR0NVgeN9pYsQ=",
+      "dev": true
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/escape-html/-/escape-html-1.0.3.tgz",
@@ -5256,9 +5250,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/events/-/events-3.1.0.tgz",
-      "integrity": "sha1-hCea8bNMt1qoi/X/KR9tC9mzGlk=",
+      "version": "3.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/events/-/events-3.2.0.tgz",
+      "integrity": "sha1-k7h8GPjvzUICpGGuxN/AVWtjk3k=",
       "dev": true
     },
     "eventsource": {
@@ -5589,15 +5583,15 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-glob/-/fast-glob-3.2.2.tgz",
-      "integrity": "sha1-reGp2RFIll1L98UfcuHKZi0y5j0=",
+      "version": "3.2.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha1-0grvv5lXk4Pn88xmUpFYybmFVNM=",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5725,12 +5719,12 @@
       }
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "3.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^3.0.0"
       }
     },
     "findup-sync": {
@@ -5867,24 +5861,10 @@
       }
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha1-r6FPCLoSpSljFA/kMhJliJe8Dss=",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
+      "version": "1.12.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/follow-redirects/-/follow-redirects-1.12.1.tgz",
+      "integrity": "sha1-3lSmIFMRuT1gOY68Ac9wFWgjErY=",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -6784,49 +6764,6 @@
         "resolve-cwd": "^2.0.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-          "dev": true
-        },
         "pkg-dir": {
           "version": "3.0.0",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -6889,9 +6826,9 @@
       }
     },
     "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha1-1QYaYiS+WOgIOYX1AU2EQ1lXYpY=",
+      "version": "1.4.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
       "dev": true
     },
     "invariant": {
@@ -6902,12 +6839,6 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
-    },
-    "invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
-      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -7309,9 +7240,9 @@
       }
     },
     "jsonc-parser": {
-      "version": "2.2.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
-      "integrity": "sha1-23PNWdeMzihyMZlGayoD0b4d8rw="
+      "version": "2.3.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/jsonc-parser/-/jsonc-parser-2.3.0.tgz",
+      "integrity": "sha1-fH/JiO4UhtNXNPqqqGb62wD6ke4="
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -7351,15 +7282,6 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
       "dev": true
-    },
-    "lcid": {
-      "version": "2.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^2.0.0"
-      }
     },
     "less": {
       "version": "3.9.0",
@@ -7441,19 +7363,19 @@
       }
     },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "version": "3.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
+        "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
+      "version": "4.17.19",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha1-5I3e2+MLMyF4PFtDAfvTU7weSks="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -7570,15 +7492,6 @@
       "integrity": "sha1-rSyVdhl8nxq/MI0Hh4Zb2XWj8+Q=",
       "dev": true
     },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/map-cache/-/map-cache-0.2.2.tgz",
@@ -7616,17 +7529,6 @@
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
-    },
-    "mem": {
-      "version": "4.3.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
-      "dev": true,
-      "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
-      }
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -7727,12 +7629,6 @@
       "requires": {
         "mime-db": "1.44.0"
       }
-    },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
-      "dev": true
     },
     "mini-css-extract-plugin": {
       "version": "0.8.0",
@@ -7999,9 +7895,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+      "version": "2.6.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "dev": true
     },
     "ngx-bootstrap": {
@@ -8090,9 +7986,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.58",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-releases/-/node-releases-1.1.58.tgz",
-      "integrity": "sha1-juIO7zD6YOUnVfzAlC3vWnNP6TU=",
+      "version": "1.1.60",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-releases/-/node-releases-1.1.60.tgz",
+      "integrity": "sha1-aUi9/OgobwtdDlqI6DhOlU3+cIQ=",
       "dev": true
     },
     "normalize-package-data": {
@@ -8340,9 +8236,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
+      "version": "1.8.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha1-34B+Xs9TpgnMa/6T6sPMe+WzqdA=",
       "dev": true
     },
     "object-is": {
@@ -8470,17 +8366,6 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -8497,40 +8382,28 @@
         "os-tmpdir": "^1.0.0"
       }
     },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
-    "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4=",
-      "dev": true
-    },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+      "version": "2.3.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "version": "3.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^2.0.0"
       }
     },
     "p-map": {
@@ -8552,9 +8425,9 @@
       }
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "version": "2.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
     "pacote": {
@@ -8930,15 +8803,6 @@
             "p-locate": "^4.1.0"
           }
         },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
         "p-locate": {
           "version": "4.1.0",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-4.1.0.tgz",
@@ -8947,12 +8811,6 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-          "dev": true
         },
         "path-exists": {
           "version": "4.0.0",
@@ -8963,18 +8821,18 @@
       }
     },
     "pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "version": "3.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha1-EA7CNcwVDk/UJRlBJZaihRKg3vU=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "^3.0.0"
       }
     },
     "portfinder": {
-      "version": "1.0.26",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/portfinder/-/portfinder-1.0.26.tgz",
-      "integrity": "sha1-R1ZY1WyjC+1yrH8TeO01C9G2TnA=",
+      "version": "1.0.27",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/portfinder/-/portfinder-1.0.27.tgz",
+      "integrity": "sha1-pBMzwRa15fPTgPl0WsLzUITEx1g=",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
@@ -9585,13 +9443,12 @@
       "dev": true
     },
     "regenerator-transform": {
-      "version": "0.14.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
-      "integrity": "sha1-UmaFeJZRjRYWp4oEeTN6MOqXTMc=",
+      "version": "0.14.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+      "integrity": "sha1-yY2hVGg2ccnE3LFuznNlF+G3/rQ=",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.8.4",
-        "private": "^0.1.8"
+        "@babel/runtime": "^7.8.4"
       }
     },
     "regex-cache": {
@@ -9877,9 +9734,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.26.8",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/sass/-/sass-1.26.8.tgz",
-      "integrity": "sha1-MSZSUwch+VaNTEAAsNsH7G6yMyU=",
+      "version": "1.26.10",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/sass/-/sass-1.26.10.tgz",
+      "integrity": "sha1-hR0SYCHNyT3svyAdHsoqIO5DR2A=",
       "dev": true,
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"
@@ -9913,26 +9770,6 @@
         "@types/json-schema": "^7.0.4",
         "ajv": "^6.12.2",
         "ajv-keywords": "^3.4.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha1-xinF7O0XuvMUQ3kY0tqIyZ1ZWM0=",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
-          "dev": true
-        }
       }
     },
     "select-hose": {
@@ -10037,9 +9874,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "3.1.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-      "integrity": "sha1-i/OpFwcSZk7yVhtEtpHq/jmSFOo=",
+      "version": "4.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -10915,122 +10752,152 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.3",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-      "integrity": "sha1-Xsry29xfuZdF/QZ5H0b8ndscmnw=",
+      "version": "3.0.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser-webpack-plugin/-/terser-webpack-plugin-3.0.3.tgz",
+      "integrity": "sha1-I72iaHsZf4eKdDNzuUEdkXrcLkU=",
       "dev": true,
       "requires": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "cacache": "^15.0.4",
+        "find-cache-dir": "^3.3.1",
+        "jest-worker": "^26.0.0",
+        "p-limit": "^2.3.0",
+        "schema-utils": "^2.6.6",
+        "serialize-javascript": "^3.1.0",
         "source-map": "^0.6.1",
-        "terser": "^4.1.2",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
+        "terser": "^4.6.13",
+        "webpack-sources": "^1.4.3"
       },
       "dependencies": {
+        "cacache": {
+          "version": "15.0.5",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacache/-/cacache-15.0.5.tgz",
+          "integrity": "sha1-aRYoM9opFw1nMjNGQ8YOAF9fF9A=",
+          "dev": true,
+          "requires": {
+            "@npmcli/move-file": "^1.0.1",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "glob": "^7.1.4",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.1",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^1.0.3",
+            "p-map": "^4.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.0",
+            "tar": "^6.0.2",
+            "unique-filename": "^1.1.1"
+          }
+        },
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4=",
+          "dev": true
+        },
         "find-cache-dir": {
-          "version": "2.1.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-          "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+          "version": "3.3.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+          "integrity": "sha1-ibM/rUpGcNqpT4Vff74x1thP6IA=",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
-            "make-dir": "^2.0.0",
-            "pkg-dir": "^3.0.0"
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
           }
         },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+        "jest-worker": {
+          "version": "26.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/jest-worker/-/jest-worker-26.1.0.tgz",
+          "integrity": "sha1-ZdVkGvdOCMzVYcJA59thKE+C8z0=",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0"
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
           }
         },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
           "dev": true,
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
+            "yallist": "^4.0.0"
           }
         },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
           "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         },
         "serialize-javascript": {
-          "version": "2.1.2",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-          "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
-          "dev": true
+          "version": "3.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+          "integrity": "sha1-i/OpFwcSZk7yVhtEtpHq/jmSFOo=",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "ssri": {
+          "version": "8.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ssri/-/ssri-8.0.0.tgz",
+          "integrity": "sha1-ecp04h+M6u3fy0uQFDxFi42YiAg=",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "terser": {
+          "version": "4.8.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser/-/terser-4.8.0.tgz",
+          "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
           "dev": true
         }
       }
@@ -11654,9 +11521,9 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.0.3",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-      "integrity": "sha1-APdJTSritojP4omd9u0sVL75Hb4=",
+      "version": "2.1.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha1-VLw83UMxe8qR413K8wWxpyN950U=",
       "dev": true
     },
     "v8flags": {
@@ -11769,12 +11636,12 @@
       }
     },
     "watchpack": {
-      "version": "1.7.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack/-/watchpack-1.7.2.tgz",
-      "integrity": "sha1-wC5NTUmRPD5+EiwzJTZa+dMx6ao=",
+      "version": "1.7.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack/-/watchpack-1.7.4.tgz",
+      "integrity": "sha1-bp2lOzyAuy1lCBiPWyAEEIZs0ws=",
       "dev": true,
       "requires": {
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0",
         "watchpack-chokidar2": "^2.0.0"
@@ -12273,6 +12140,17 @@
             }
           }
         },
+        "find-cache-dir": {
+          "version": "2.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^2.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-3.0.0.tgz",
@@ -12291,6 +12169,16 @@
                 "is-buffer": "^1.1.5"
               }
             }
+          }
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
           }
         },
         "micromatch": {
@@ -12314,6 +12202,15 @@
             "to-regex": "^3.0.2"
           }
         },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -12323,6 +12220,44 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        },
+        "serialize-javascript": {
+          "version": "3.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+          "integrity": "sha1-i/OpFwcSZk7yVhtEtpHq/jmSFOo=",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "terser-webpack-plugin": {
+          "version": "1.4.4",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
+          "integrity": "sha1-LGNUQ0cyS6r6mla6rd8WNMir/C8=",
+          "dev": true,
+          "requires": {
+            "cacache": "^12.0.2",
+            "find-cache-dir": "^2.1.0",
+            "is-wsl": "^1.1.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^3.1.0",
+            "source-map": "^0.6.1",
+            "terser": "^4.1.2",
+            "webpack-sources": "^1.4.0",
+            "worker-farm": "^1.7.0"
           }
         },
         "to-regex-range": {
@@ -12338,66 +12273,61 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.11",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack-cli/-/webpack-cli-3.3.11.tgz",
-      "integrity": "sha1-O/IYib9Ze12Cw48hUTWkEe39xjE=",
+      "version": "3.3.12",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack-cli/-/webpack-cli-3.3.12.tgz",
+      "integrity": "sha1-lOmtoIFFPNCqYJyZ5QABL9OtLUo=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "cross-spawn": "6.0.5",
-        "enhanced-resolve": "4.1.0",
-        "findup-sync": "3.0.0",
-        "global-modules": "2.0.0",
-        "import-local": "2.0.0",
-        "interpret": "1.2.0",
-        "loader-utils": "1.2.3",
-        "supports-color": "6.1.0",
-        "v8-compile-cache": "2.0.3",
-        "yargs": "13.2.4"
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "enhanced-resolve": "^4.1.1",
+        "findup-sync": "^3.0.0",
+        "global-modules": "^2.0.0",
+        "import-local": "^2.0.0",
+        "interpret": "^1.4.0",
+        "loader-utils": "^1.4.0",
+        "supports-color": "^6.1.0",
+        "v8-compile-cache": "^2.1.1",
+        "yargs": "^13.3.2"
       },
       "dependencies": {
-        "find-up": {
+        "emojis-list": {
           "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
           "dev": true
+        },
+        "enhanced-resolve": {
+          "version": "4.3.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+          "integrity": "sha1-O4BvO/r8HsfeaVUe+TzKRsFwQSY=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha1-MkwBKIuIZSlm0WHbd4OHIIRajjw=",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
         },
         "supports-color": {
           "version": "6.1.0",
@@ -12406,25 +12336,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.2.4",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yargs/-/yargs-13.2.4.tgz",
-          "integrity": "sha1-C1YreUAW65ZRuYvTes82SqXW3IM=",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "os-locale": "^3.1.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.0"
           }
         }
       }
@@ -12985,51 +12896,6 @@
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
         "yargs-parser": "^13.1.2"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-          "dev": true
-        }
       }
     },
     "yargs-parser": {

--- a/webClient/package.json
+++ b/webClient/package.json
@@ -4,7 +4,7 @@
   "license": "EPL-2.0",
   "scripts": {
     "start": "webpack --config ./webpack.build.config.js --watch --progress",
-    "build": "webpack --config ./webpack.build.config.js --progress",
+    "build": "webpack --config ./webpack.build.config.js --progress && node prune.js",
     "lint": "tslint -c tslint.json \"./**/*.ts\""
   },
   "dependencies": {

--- a/webClient/prune.js
+++ b/webClient/prune.js
@@ -1,0 +1,27 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
+const fs = require('fs');
+const path = require('path');
+const files = fs.readdirSync(path.join('..','web'));
+for (let i = 0; i < files.length; i++) {
+  if (files[i].endsWith('.map.gz')) {
+    fs.unlinkSync(path.join('..','web',files[i]));
+  } else if (files[i].endsWith('.map')) {
+    fs.unlinkSync(path.join('..','web',files[i]));
+  } else if (files[i].endsWith('.gz')) {
+    for (let j = 0; j < files.length; j++) {
+      if (files[j] == files[i].substring(0,files[i].length-3)) {
+        fs.unlinkSync(path.join('..','web',files[j]));
+      }
+    }
+  }
+}

--- a/webClient/webpack.build.config.js
+++ b/webClient/webpack.build.config.js
@@ -76,7 +76,7 @@ var config = {
       }
     ]),
     new CompressionPlugin({
-      threshold: 100000,
+      threshold: 50000,
       minRatio: 0.8
     })
     , new MonacoWebpackPlugin({publicPath: pubPath})


### PR DESCRIPTION
This significantly reduces the package size of the editor by removing assets that are unlikely to be used.
Specifically, .map files (used for development moreso than end-use) and files that have gzip variants (ALL browsers support gzip, so it's not very likely that non-gzip fallback is needed)
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>