### PR TITLE
Reviewed keybindings, added some general QoL improvements

### DIFF
--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -48,6 +48,7 @@ export class AppComponent {
 
     const editorheaderElement = this.editorheaderElementRef.nativeElement;
     this.appKeyboard.registerKeyUpEvent(editorheaderElement);
+    this.appKeyboard.registerKeyDownEvent(editorheaderElement);
   }
 
   handleLaunchOrMessageObject(data: any) {

--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -306,23 +306,23 @@ export class MenuBarComponent implements OnInit, OnDestroy {
     }       
 
     this.keyBindingSub.add(this.appKeyboard.keydownEvent
-      .filter(value => value.altKey).subscribe((event) => {
-        if (event.altKey && event.which === KeyCode.KEY_N) {
+      .subscribe((event) => {
+        if (event.which === KeyCode.KEY_N) {
           this.createFile();
-        } else if (event.altKey && event.which === KeyCode.KEY_M) {
+        } else if (event.which === KeyCode.KEY_M) {
           this.getMenuSectionElements()[0].focus();
-        } else if (event.altKey && event.which === KeyCode.KEY_O) {
+        } else if (event.which === KeyCode.KEY_O) {
           this.openDirectory();
-        } else if (event.altKey && event.which === KeyCode.KEY_K) {
+        } else if (event.which === KeyCode.KEY_K) {
           this.openDatasets();
-        } else if (event.altKey && event.which === KeyCode.KEY_P) {
+        } else if (event.which === KeyCode.KEY_P) {
           this.getSearchFocus();
-        } else if (event.altKey && event.which === KeyCode.KEY_1) {
+        } else if (event.which === KeyCode.KEY_1) {
           this.getEditorFocus();
-        } else if (event.altKey && event.which === KeyCode.KEY_W && event.shiftKey) {
+        } else if (event.which === KeyCode.KEY_W && event.shiftKey) {
           this.closeAll();
         }
-        // else if (event.altKey && event.which === KeyCode.KEY_S && event.ctrlKey) { TODO
+        // else if (event.which === KeyCode.KEY_S && event.ctrlKey) { TODO
         //   this.saveAll();
         // }
     }));

--- a/webClient/src/app/editor/code-editor/code-editor.component.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.component.ts
@@ -138,19 +138,19 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
     })
 
     this.keyBindingSub.add(this.appKeyboard.keydownEvent.subscribe((event) => {
-      if (event.altKey && event.which === KeyCode.KEY_T && event.ctrlKey) {
+      if (event.which === KeyCode.KEY_T && event.ctrlKey) {
         this.editorControl.undoCloseFile.next();
       }
     }));
 
     this.keyBindingSub.add(this.appKeyboard.keyupEvent.subscribe((event) => {
-      if (event.altKey && (event.which === KeyCode.PAGE_DOWN || event.which === KeyCode.PERIOD)) {
+      if (event.which === KeyCode.PAGE_DOWN || event.which === KeyCode.PERIOD) {
         let fileContext = this.editorControl.fetchRightOfActiveFile();
         this.selectFile(fileContext, true);      
-      } else if (event.altKey && (event.which === KeyCode.PAGE_UP || event.which === KeyCode.COMMA)) {
+      } else if (event.which === KeyCode.PAGE_UP || event.which === KeyCode.COMMA) {
         let fileContext = this.editorControl.fetchLeftOfActiveFile();
         this.selectFile(fileContext, true);      
-      } else if (event.altKey && event.which === KeyCode.KEY_W && !event.shiftKey) { // Separate keybinding for "close all"
+      } else if (event.which === KeyCode.KEY_W && !event.shiftKey) { // Separate keybinding for "close all"
         let fileContext = this.editorControl.fetchActiveFile();
         this.closeFile(fileContext);
         setTimeout(()=> {

--- a/webClient/src/app/editor/code-editor/code-editor.component.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.component.ts
@@ -33,7 +33,7 @@ const DEFAULT_TITLE = 'Editor';
 export class CodeEditorComponent implements OnInit, OnDestroy {
   private openFileList: ProjectContext[];
   private noOpenFile: boolean;
-  private subscription:Subscription = new Subscription();
+  private keyBindingSub:Subscription = new Subscription();
   @ViewChild('monaco')
   monacoRef: ElementRef;
 
@@ -87,10 +87,30 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
     });
 
     this.editorControl.closeFile.subscribe((fileContext: ProjectContext) => {
+      this.previousSessionData.noOpenFile = this.noOpenFile;
+      this.previousSessionData.editorFile = this.editorFile;
+      this.previousSessionData.openFileList = this.openFileList;
+
       if (!this.noOpenFile && !this.isAnySelected()) {
         this.selectFile(this.openFileList[0], true);
       }
     });
+
+    this.editorControl.undoCloseFile.subscribe(() => {
+      if (this.previousSessionData.noOpenFile) {
+        this.noOpenFile = this.previousSessionData.noOpenFile;
+      }
+      if (this.previousSessionData.editorFile) {
+        this.editorFile = this.previousSessionData.editorFile;
+
+        this.editorFile.context.active = true;
+        this.editorFile.context.opened = true;
+
+        this.selectFile(this.editorFile.context, true);
+        this.editorControl.openFileHandler(this.editorFile.context);
+      }
+      this.updateEditorTitle();
+    })
 
     this.editorControl.closeAllFiles.subscribe(() => {
       this.previousSessionData.noOpenFile = this.noOpenFile;
@@ -108,9 +128,8 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
       if (this.previousSessionData.editorFile) {
         this.editorFile = this.previousSessionData.editorFile;
 
-        /* Let editorControl set it to active & opened naturally, otherwise verbose debug logs */
-        this.editorFile.context.active = false;
-        this.editorFile.context.opened = false;
+        this.editorFile.context.active = true;
+        this.editorFile.context.opened = true;
 
         this.selectFile(this.editorFile.context, true);
         this.editorControl.openFileHandler(this.editorFile.context);
@@ -118,13 +137,25 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
       this.updateEditorTitle();
     })
 
-    this.subscription.add(this.appKeyboard.keyupEvent.subscribe((event) => {
-      if (event.altKey && event.which === KeyCode.KEY_T) {
-        let fileContext = this.editorControl.fetchAdjToActiveFile();
+    this.keyBindingSub.add(this.appKeyboard.keydownEvent.subscribe((event) => {
+      if (event.altKey && event.which === KeyCode.KEY_T && event.ctrlKey) {
+        this.editorControl.undoCloseFile.next();
+      }
+    }));
+
+    this.keyBindingSub.add(this.appKeyboard.keyupEvent.subscribe((event) => {
+      if (event.altKey && event.which === KeyCode.PAGE_DOWN) {
+        let fileContext = this.editorControl.fetchRightOfActiveFile();
+        this.selectFile(fileContext, true);      
+      } else if (event.altKey && event.which === KeyCode.PAGE_UP) {
+        let fileContext = this.editorControl.fetchLeftOfActiveFile();
         this.selectFile(fileContext, true);      
       } else if (event.altKey && event.which === KeyCode.KEY_W && !event.shiftKey) { // Separate keybinding for "close all"
         let fileContext = this.editorControl.fetchActiveFile();
         this.closeFile(fileContext);
+        setTimeout(()=> {
+          this.editorControl.getFocus();
+        });
       }
     }));
 
@@ -184,9 +215,7 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
     
   }
 
-  //TODO this is causing the error of nothing showing up when a tab is closed
   closeFile(fileContext: ProjectContext) {
-    this.editorFile = undefined;
     this.codeEditorService.closeFile(fileContext);
   }
 
@@ -217,7 +246,7 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy():void {
-    this.subscription.unsubscribe();
+    this.keyBindingSub.unsubscribe();
   }
 }
 

--- a/webClient/src/app/editor/code-editor/code-editor.component.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.component.ts
@@ -144,10 +144,10 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
     }));
 
     this.keyBindingSub.add(this.appKeyboard.keyupEvent.subscribe((event) => {
-      if (event.altKey && event.which === KeyCode.PAGE_DOWN) {
+      if (event.altKey && (event.which === KeyCode.PAGE_DOWN || event.which === KeyCode.PERIOD)) {
         let fileContext = this.editorControl.fetchRightOfActiveFile();
         this.selectFile(fileContext, true);      
-      } else if (event.altKey && event.which === KeyCode.PAGE_UP) {
+      } else if (event.altKey && (event.which === KeyCode.PAGE_UP || event.which === KeyCode.COMMA)) {
         let fileContext = this.editorControl.fetchLeftOfActiveFile();
         this.selectFile(fileContext, true);      
       } else if (event.altKey && event.which === KeyCode.KEY_W && !event.shiftKey) { // Separate keybinding for "close all"

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -45,6 +45,10 @@ export class MonacoService {
       this.closeFile(fileContext);
     });
 
+    this.editorControl.closeAllFiles.subscribe(() => {
+      this.closeAllFiles();
+    });
+
     this.editorControl.changeLanguage.subscribe(e => {
       let openList = this.editorControl.openFileList.getValue();
       if (openList.length > 0) {
@@ -203,6 +207,19 @@ export class MonacoService {
       if (model.uri === fileUri) {
         model.dispose();
       }
+    }
+  }
+
+  closeAllFiles() {
+    const editorCore = this.editorControl.editorCore.getValue();
+    if (!editorCore) {
+      console.warn(`Editor core null on closeFile()`);
+      return;
+    }
+    const _editor = editorCore.editor;
+    const models = _editor.getModels();
+    for (const model of models) {
+      model.dispose();
     }
   }
 

--- a/webClient/src/app/editor/frame/frame.component.html
+++ b/webClient/src/app/editor/frame/frame.component.html
@@ -9,7 +9,7 @@
   Copyright Contributors to the Zowe Project.
 -->
 <div class="main-container">
-  <aside class="gz-tree">
+  <aside class="gz-tree" [style.maxWidth]="showExplorer ? '315px':'0px'">
     <div class="section-container" [ngClass]="{'active':this.activityBar[0].active}">
       <app-project-tree></app-project-tree>
     </div>

--- a/webClient/src/app/editor/frame/frame.component.scss
+++ b/webClient/src/app/editor/frame/frame.component.scss
@@ -56,7 +56,6 @@
     }
     .gz-tree {
       width: fit-content;
-      max-width: 315px;
       height: 100%;
       color: white;
       background-color: #303030; // float: left;

--- a/webClient/src/app/editor/frame/frame.component.ts
+++ b/webClient/src/app/editor/frame/frame.component.ts
@@ -80,7 +80,7 @@ export class FrameComponent implements OnInit, OnDestroy {
     });
 
     this.keyBindingSub.add(this.appKeyboard.keydownEvent.subscribe((event) => {
-      if (event.altKey && event.which === KeyCode.KEY_B) {
+      if (event.which === KeyCode.KEY_B) {
         this.showExplorer = !this.showExplorer;
         if (this.windowActions) { // Window manager lack of re-rendering bug
           this.windowActions.maximize();

--- a/webClient/src/app/editor/frame/frame.component.ts
+++ b/webClient/src/app/editor/frame/frame.component.ts
@@ -8,7 +8,7 @@
   
   Copyright Contributors to the Zowe Project.
 */
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit, Optional } from '@angular/core';
 import { EditorControlService } from '../../shared/editor-control/editor-control.service';
 import { ProjectContext } from '../../shared/model/project-context';
 import { LineMapping } from '../../shared/model/line-mapping';
@@ -17,13 +17,18 @@ import { ENDPOINTS } from '../../../environments/environment';
 import { HttpService } from '../../shared/http/http.service';
 import { MonacoService } from '../code-editor/monaco/monaco.service';
 import * as _ from 'lodash';
+import { Subscription } from 'rxjs/Rx';
+import { EditorKeybindingService } from '../../shared/editor-keybinding.service';
+import { KeyCode } from '../../shared/keycode-enum';
+import { Angular2InjectionTokens, Angular2PluginWindowActions } from 'pluginlib/inject-resources';
+
 
 @Component({
   selector: 'app-frame',
   templateUrl: './frame.component.html',
   styleUrls: ['./frame.component.scss',  '../../../styles.scss']
 })
-export class FrameComponent implements OnInit {
+export class FrameComponent implements OnInit, OnDestroy {
 
   private expendPanelOptions = {
     collapsedHeight: '24px',
@@ -35,6 +40,8 @@ export class FrameComponent implements OnInit {
   private fileResultList = [];
   private contentResultList: LineMapping[] = [];
   private cantSearch = true;
+  private showExplorer = true;
+  private keyBindingSub: Subscription = new Subscription();
   private activityBar = [
     {
       name: 'Explorer',
@@ -58,7 +65,9 @@ export class FrameComponent implements OnInit {
     private editorControl: EditorControlService,
     private utils: UtilsService,
     private http: HttpService,
-    private monacoService: MonacoService) {
+    private monacoService: MonacoService,
+    private appKeyboard: EditorKeybindingService,
+    @Optional() @Inject(Angular2InjectionTokens.WINDOW_ACTIONS) private windowActions: Angular2PluginWindowActions) {
     // this.editorControl.context.subscribe((context) => {
     //   context != null ? this.showSearchBar = true : this.showSearchBar = false;
     // });
@@ -69,9 +78,23 @@ export class FrameComponent implements OnInit {
     this.editorControl.openProject.subscribe(() => {
       this.cantSearch = false;
     });
+
+    this.keyBindingSub.add(this.appKeyboard.keydownEvent.subscribe((event) => {
+      if (event.altKey && event.which === KeyCode.KEY_B) {
+        this.showExplorer = !this.showExplorer;
+        if (this.windowActions) { // Window manager lack of re-rendering bug
+          this.windowActions.maximize();
+          this.windowActions.restore();
+        }
+      }
+    }));
   }
 
   ngOnInit() {
+  }
+
+  ngOnDestroy() {
+    this.keyBindingSub.unsubscribe();
   }
 
   disableInput() {

--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -112,6 +112,10 @@ export class ProjectTreeComponent {
       this.editorControl.undoCloseAllHandler();
     })
 
+    this.editorControl.undoCloseFile.subscribe(() => {
+      this.editorControl.undoCloseFileHandler();
+    })
+
     this.editorControl.openProject.subscribe(projectName => {
       if (projectName != null) {
         // start get project structure

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -55,6 +55,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   public openFileEmitter: EventEmitter<ProjectStructure> = new EventEmitter();
   public languageRegistered: EventEmitter<ProjectStructure> = new EventEmitter();
   public closeFile: EventEmitter<ProjectContext> = new EventEmitter();
+  public undoCloseFile: EventEmitter<string> = new EventEmitter();
   public selectFile: EventEmitter<ProjectContext> = new EventEmitter();
   public saveFile: EventEmitter<ProjectContext> = new EventEmitter();
   public initializedFile: EventEmitter<ProjectContext> = new EventEmitter();
@@ -228,6 +229,8 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
 
   public closeFileHandler(fileContext: ProjectContext) {
     let cacheFileName = `${fileContext.model.fileName}:${fileContext.model.path}`;
+    this.previousSessionData.stateCache = stateCache;
+    this.previousSessionData._openFileList = this._openFileList.getValue();
     if (cacheFileName) {
       this.log.debug(`Clearing cache for`,cacheFileName);
       delete stateCache[cacheFileName];
@@ -236,6 +239,16 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     !fileContext.active ? this.log.warn(`File ${fileContext.name} already inactive.`) : fileContext.active = false;
     fileContext.changed = false;
     this._openFileList.next(this._openFileList.getValue().filter((file) => (file.model.fileName !== fileContext.model.fileName || file.model.path !== fileContext.model.path)));
+  }
+
+  public undoCloseFileHandler() {
+    this.log.debug("Attempting to restore session with data: ", this.previousSessionData);
+    if (this.previousSessionData.stateCache) {
+      stateCache = this.previousSessionData.stateCache;
+    }
+    if (this.previousSessionData._openFileList) {
+      this._openFileList.next(this.previousSessionData._openFileList);
+    }
   }
 
   public closeAllHandler() {
@@ -341,9 +354,18 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     return activeFile;
   }
 
-  public fetchAdjToActiveFile(): ProjectContext {
+  public fetchRightOfActiveFile(): ProjectContext {
     let openFileListVal = this._openFileList.getValue();
     let adjIdx = (openFileListVal.indexOf(this.fetchActiveFile())+1)%openFileListVal.length;
+    return openFileListVal[adjIdx];
+  }
+
+  public fetchLeftOfActiveFile(): ProjectContext {
+    let openFileListVal = this._openFileList.getValue();
+    let adjIdx = (openFileListVal.indexOf(this.fetchActiveFile())-1)%openFileListVal.length;
+    if (adjIdx < 0) {
+      adjIdx = openFileListVal.length-1;
+    }
     return openFileListVal[adjIdx];
   }
 

--- a/webClient/src/app/shared/editor-keybinding.service.ts
+++ b/webClient/src/app/shared/editor-keybinding.service.ts
@@ -17,9 +17,11 @@ import { Subject, Observable } from 'rxjs/Rx';
 @Injectable()
 export class EditorKeybindingService {
   public keyupEvent: Subject<KeyboardEvent>;
+  public keydownEvent: Subject<KeyboardEvent>;
 
   constructor() {
     this.keyupEvent = new Subject();
+    this.keydownEvent = new Subject();
   }
 
   registerKeyUpEvent(appChild:Element) {
@@ -28,6 +30,14 @@ export class EditorKeybindingService {
     observable
       .filter(value => value.altKey)
       .subscribe(this.keyupEvent);
+  }
+
+  registerKeyDownEvent(appChild:Element) {
+    let elm = appChild.closest('app-root');
+    const observable = Observable.fromEvent(elm, 'keydown' ) as Observable<KeyboardEvent>;
+    observable
+      .filter(value => value.altKey)
+      .subscribe(this.keydownEvent);
   }
 }
 


### PR DESCRIPTION
- Added backwards traversing of the open file tabs, now we have forwards and backwards via Alt + (PAGEUP or **<**) and Alt + (PAGEDOWN or **>**)
- Added & changed some to use keydown, which makes the UX a little more responsive
- When you close a tab, you can undo the close via CTRL + ALT + T
- When you close all tabs, you can undo the whole close via CTRL + ALT + T
- Fixed a bug where if you would close all tabs, then click undo, the Languages menu would disappear
- Changed search to be ALT + P instead of ALT + S (CTRL + ALT + S is often save all/save as), added ALT + B to hide/show the File Tree

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>