### PR TITLE
Stopped event propagation to remove conflict with Firefox

### DIFF
--- a/webClient/src/app/editor/frame/frame.component.ts
+++ b/webClient/src/app/editor/frame/frame.component.ts
@@ -86,6 +86,8 @@ export class FrameComponent implements OnInit, OnDestroy {
           this.windowActions.maximize();
           this.windowActions.restore();
         }
+        event.stopImmediatePropagation();
+        event.preventDefault();
       }
     }));
   }


### PR DESCRIPTION
Alt opens up their settings menu. Chrome handles it well by not opening it if it's a combo w/ another key, but Firefox doesn't

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>