### PR TITLE
Settings menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 # Copyright Contributors to the Zowe Project.
 /web
 .vscode/*
+
+#emacs
+**/*~
+**/#*#
+**/.#*
+
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `2.6.0`
+
+- Added a preferences menu to customize the editing behavior and color theme. The preferences can be previewed in realtime, but can also be saved to the app-server so that they are applied every time the editor is opened.
+
 ## `2.5.0`
 
 - Added a refresh file option to fetch up to date contents (right click file tab OR top left menu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## `2.6.0`
 
 - Added a preferences menu to customize the editing behavior and color theme. The preferences can be previewed in realtime, but can also be saved to the app-server so that they are applied every time the editor is opened.
+- Added undo and redo menu items when editing a file
 
 ## `2.5.0`
 

--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.zowe.editor",
   "apiVersion": "1.0.0",
-  "pluginVersion": "2.5.0",
+  "pluginVersion": "2.6.0",
   "license": "EPL-2.0",
   "author": "Zowe",
   "homepage": "https://github.com/zowe/zlux-editor",
@@ -29,6 +29,9 @@
             "aggregationPolicy": "override"
           }
         }
+      },
+      "monaco": {
+        "aggregationPolicy": "none"
       }
     }
   }

--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -675,6 +675,14 @@ export class MenuBarComponent implements OnInit, OnDestroy {
     });
   }
 
+  undo() {
+    this.editorControl.editor.getValue().getModel(this.editorControl.fetchActiveFile().model).undo();
+  }
+
+  redo() {
+    this.editorControl.editor.getValue().getModel(this.editorControl.fetchActiveFile().model).redo();
+  }
+
   languageServerSetting() {
     let newFileRef = this.dialog.open(LanguageServerComponent, {
       width: '500px'

--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -29,6 +29,7 @@ import { Angular2InjectionTokens, Angular2PluginSessionEvents } from 'pluginlib/
 import { Subscription } from 'rxjs/Rx';
 import { EditorKeybindingService } from '../../shared/editor-keybinding.service';
 import { KeyCode } from '../../shared/keycode-enum';
+import { ProjectContext, ProjectContextType } from '../../shared/model/project-context';
 
 function initMenu(menuItems) {
   menuItems.forEach(function(menuItem) {
@@ -115,9 +116,17 @@ export class MenuBarComponent implements OnInit, OnDestroy {
     this.editorControl.languageRegistered.subscribe((languageDefinition)=> {
       this.resetLanguageSelectionMenu();
     });
+
+    this.editorControl.openSettings.subscribe(() => {
+      this.hideFileMenus();
+    });
+    
+    this.editorControl.selectMenu.subscribe((fileContext)=> {
+      this.setMenus(fileContext);
+    });
     
     this.editorControl.selectFile.subscribe((fileContext)=> {
-      if (this.fileCount != 0){this.showLanguageMenu(fileContext.model.language);}
+      if (this.fileCount != 0){this.showFileMenus(fileContext);}
          // get focus of editor
       setTimeout(()=> {
         this.editorControl.getFocus();
@@ -125,7 +134,7 @@ export class MenuBarComponent implements OnInit, OnDestroy {
     });
 
     this.editorControl.initializedFile.subscribe((fileContext)=> {
-      this.showLanguageMenu(fileContext.model.language);
+      this.showFileMenus(fileContext);
       this.fileCount++;
       this.log.debug(`fileCount now=`,this.fileCount);
     });
@@ -138,7 +147,7 @@ export class MenuBarComponent implements OnInit, OnDestroy {
       } else {
         this.log.warn(`Open file count cannot be made negative`);
       }
-      this.removeLanguageMenu();
+      this.hideFileMenus();
     });
 
     this.editorControl.undoCloseFile.subscribe(() => {
@@ -161,7 +170,7 @@ export class MenuBarComponent implements OnInit, OnDestroy {
 
       this.fileCount = 0;
       this.log.debug('fileCount emptied');
-      this.removeLanguageMenu();
+      this.hideFileMenus();
     })
 
     this.editorControl.undoCloseAllFiles.subscribe(() => {
@@ -198,6 +207,61 @@ export class MenuBarComponent implements OnInit, OnDestroy {
 
   }
 
+  private hideFileMenus() {
+    this.removeLanguageMenu();
+    this.hideEditOptions();
+  }
+
+  private setMenus(fileContext: ProjectContext) {
+    if (fileContext.type == ProjectContextType.menu) {
+      this.hideFileMenus(); 
+    } else {
+      this.showFileMenus(fileContext);
+    }
+  }
+
+  private showFileMenus(fileContext: ProjectContext) {
+    this.showLanguageMenu(fileContext.model.language);
+    this.showEditOptions();
+  }
+
+  private showEditOptions() {
+    for (let i = 0; i < this.menuList.length; i++) {
+      let menu = this.menuList[i];
+      if (menu.name == 'Edit' && menu.children.length == 1) {
+        menu.children.unshift({
+          name: 'Undo',
+          action: {
+            internalName: 'undo'
+          }
+        });
+        menu.children.unshift({
+          name: 'Redo',
+          action: {
+            internalName: 'redo'
+          }
+        });
+        return;
+      }
+    }
+  }
+
+  private hideEditOptions() {
+    for (let i = 0; i < this.menuList.length; i++) {
+      let menu = this.menuList[i];
+      if (menu.name == 'Edit' && menu.children.length > 1) {
+        menu.children.shift();//redo
+        menu.children.shift();//undo
+        return;
+      }
+    }
+  }
+  
+  private showSettings() {
+    this.editorControl.openSettings.next();
+  }
+
+  
   getMenuSectionElements() {
     return this.menuBarRef.nativeElement.getElementsByClassName("gz-menu-section");
   }

--- a/webClient/src/app/core/menu-bar/menu-bar.config.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.config.ts
@@ -203,6 +203,17 @@ export const MENU = [
             //},
         ],
     },
+    {
+        name: 'Edit',
+        children: [
+            {
+                name: 'Preferences',
+                action: {
+                    internalName: 'showSettings'
+                }
+            }
+        ]
+    }
     // {
     //     name: 'Language Server',
     //     children: [

--- a/webClient/src/app/editor/code-editor/code-editor.component.html
+++ b/webClient/src/app/editor/code-editor/code-editor.component.html
@@ -22,7 +22,7 @@
     (select)="selectFile($event, true)" 
     (remove)="closeFile($event)"></app-file-tabs>
   <app-monaco-settings (options)="setOptions($event)" *ngIf="showSettings"></app-monaco-settings>
-  <app-monaco *ngIf="!showSettings" [editorFile]="editorFile" [options]="options" #monaco></app-monaco>
+  <app-monaco [editorFile]="editorFile" [options]="options" #monaco></app-monaco>
 </div>
 
 <!-- 

--- a/webClient/src/app/editor/code-editor/code-editor.component.html
+++ b/webClient/src/app/editor/code-editor/code-editor.component.html
@@ -8,7 +8,7 @@
   
   Copyright Contributors to the Zowe Project.
 -->
-<div class="editor-instruction" *ngIf="noOpenFile">
+<div class="editor-instruction" *ngIf="noOpenFile && !showSettings">
   <div class="instruction">
     <span class="welcome" style="color: #6ba4ff">Zowe Editor</span>
     <p>Use the explorer on the left-hand side to start your journey!
@@ -17,12 +17,12 @@
 </div>
 <div class="code-editor-container">
   <app-file-tabs [data]="openFileList" 
-    (click)="focusMonaco()" 
+    (click)="focus()" 
     (refresh)="refreshFile($event, true)" 
     (select)="selectFile($event, true)" 
     (remove)="closeFile($event)"></app-file-tabs>
-  <!--<app-monaco-settings *ngIf="showSettings"></app-monaco-settings>-->
-  <app-monaco [editorFile]="editorFile" [options]="options" #monaco></app-monaco>
+  <app-monaco-settings (options)="setOptions($event)" *ngIf="showSettings"></app-monaco-settings>
+  <app-monaco *ngIf="!showSettings" [editorFile]="editorFile" [options]="options" #monaco></app-monaco>
 </div>
 
 <!-- 

--- a/webClient/src/app/editor/code-editor/code-editor.component.html
+++ b/webClient/src/app/editor/code-editor/code-editor.component.html
@@ -21,6 +21,7 @@
     (refresh)="refreshFile($event, true)" 
     (select)="selectFile($event, true)" 
     (remove)="closeFile($event)"></app-file-tabs>
+  <!--<app-monaco-settings *ngIf="showSettings"></app-monaco-settings>-->
   <app-monaco [editorFile]="editorFile" [options]="options" #monaco></app-monaco>
 </div>
 

--- a/webClient/src/app/editor/code-editor/code-editor.component.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.component.ts
@@ -82,7 +82,7 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
       });
     }
     this.http.get<any>(ZoweZLUX.uriBroker.pluginConfigForScopeUri(this.pluginDefinition.getBasePlugin(),'user','monaco','editorconfig.json')).subscribe((response: any) => {
-      if (response.contents) {
+      if (response && response.contents && response.contents.config) {
         this.options = response.contents.config;
       }
     });

--- a/webClient/src/app/editor/code-editor/code-editor.component.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.component.ts
@@ -159,9 +159,9 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
         this.openFileList.push({
           type: ProjectContextType.menu,
           name: "Settings",
-          id: "org.zowe.zlux.editor.settings",
+          id: "org.zowe.editor.settings",
           model: {
-            id: "org.zowe.zlux.editor.settings",
+            id: "org.zowe.editor.settings",
             name: "Settings",
             hasChildren: false,
             isDataset: false
@@ -177,7 +177,7 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
         this.showSettings = false;
         this.settingsOpen = false;
         for (let i = 0; i < this.openFileList.length; i++) {
-          if (this.openFileList[i].id == 'org.zowe.zlux.editor.settings') {
+          if (this.openFileList[i].id == 'org.zowe.editor.settings') {
             this.openFileList.splice(i, 1);
           }
         }

--- a/webClient/src/app/editor/code-editor/code-editor.component.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.component.ts
@@ -17,7 +17,7 @@ import { ENDPOINTS } from '../../../environments/environment';
 import { MonacoService } from './monaco/monaco.service';
 import { ProjectStructure } from '../../shared/model/editor-project';
 import { EditorService } from '../editor.service';
-import { ProjectContext } from '../../shared/model/project-context';
+import { ProjectContext, ProjectContextType } from '../../shared/model/project-context';
 import { CodeEditorService } from './code-editor.service';
 import { EditorKeybindingService } from '../../shared/editor-keybinding.service';
 import { KeyCode } from '../../shared/keycode-enum';
@@ -39,8 +39,8 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
   monacoRef: ElementRef;
 
   public showSettings: boolean = false;
+  public settingsOpen: boolean = false;
 
-  //TODO load from configservice
   public options;
   /*
     = {
@@ -78,18 +78,24 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
     private codeEditorService: CodeEditorService) {
     if (this.windowEvents) {
       this.windowEvents.restored.subscribe(()=> {
-        this.focusMonaco();
+        this.focus();
       });
     }
     this.http.get<any>(ZoweZLUX.uriBroker.pluginConfigForScopeUri(this.pluginDefinition.getBasePlugin(),'user','monaco','editorconfig.json')).subscribe((response: any) => {
       if (response.contents) {
         this.options = response.contents.config;
-        console.log('code-editor.component.ts set options=',this.options);
       }
     });
     
     //respond to the request to open
     this.editorControl.openFileEmitter.subscribe((fileNode: ProjectStructure) => {
+      if (this.settingsOpen && this.showSettings) {
+        this.showSettings = false;
+        if (this.monacoRef) {
+          (this.monacoRef as any).focus();
+          (this.monacoRef as any).layout();
+        }
+      }
       this.openFile(fileNode);
       this.editorControl.editor.getValue().layout();
     });
@@ -102,13 +108,7 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
     });
 
     this.editorControl.closeFile.subscribe((fileContext: ProjectContext) => {
-      this.previousSessionData.noOpenFile = this.noOpenFile;
-      this.previousSessionData.editorFile = this.editorFile;
-      this.previousSessionData.openFileList = this.openFileList;
-
-      if (!this.noOpenFile && !this.isAnySelected()) {
-        this.selectFile(this.openFileList[0], true);
-      }
+      this.handleCloseFile(fileContext);
     });
 
     this.editorControl.undoCloseFile.subscribe(() => {
@@ -152,6 +152,38 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
       this.updateEditorTitle();
     })
 
+    this.editorControl.openSettings.subscribe(() => {
+      if (!this.settingsOpen) {
+        this.showSettings = true;
+        this.settingsOpen = true;
+        this.openFileList.push({
+          type: ProjectContextType.menu,
+          name: "Settings",
+          id: "org.zowe.zlux.editor.settings",
+          model: {
+            id: "org.zowe.zlux.editor.settings",
+            name: "Settings",
+            hasChildren: false,
+            isDataset: false
+          },
+          opened: true,
+          active: true, //TODO what happens to previously active file
+          changed: false        
+        });
+      }
+    });
+    this.editorControl.closeSettings.subscribe(() => {
+      if (this.settingsOpen) {
+        this.showSettings = false;
+        this.settingsOpen = false;
+        for (let i = 0; i < this.openFileList.length; i++) {
+          if (this.openFileList[i].id == 'org.zowe.zlux.editor.settings') {
+            this.openFileList.splice(i, 1);
+          }
+        }
+      }
+    });
+
     this.keyBindingSub.add(this.appKeyboard.keydownEvent.subscribe((event) => {
       if (event.which === KeyCode.KEY_T && event.ctrlKey) {
         this.editorControl.undoCloseFile.next();
@@ -176,6 +208,12 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
 
   }
 
+  setOptions(options: any) {
+    if (typeof options == 'object') {
+      this.options = options;
+    }
+  }
+  
   updateEditorTitle():void {
     if(this.noOpenFile) {
       this.setTitle();
@@ -198,8 +236,10 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
     return typeof(this.getActiveFile()) != "undefined";
   }
 
-  focusMonaco() {
-    (this.monacoRef as any).focus();
+  focus() {
+    if (!this.showSettings) {
+      (this.monacoRef as any).focus();
+    }
   }
 
   ngOnInit() { }
@@ -230,8 +270,25 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
     
   }
 
+  private handleCloseFile(fileContext: ProjectContext) {
+    this.previousSessionData.noOpenFile = this.noOpenFile;
+    this.previousSessionData.editorFile = this.editorFile;
+    this.previousSessionData.openFileList = this.openFileList;
+
+    if (!this.noOpenFile && !this.isAnySelected()) {
+      this.selectFile(this.openFileList[0], true);
+    }
+  }
+
   closeFile(fileContext: ProjectContext) {
-    this.codeEditorService.closeFile(fileContext);
+    if (fileContext.type == ProjectContextType.menu) {
+      this.editorControl.closeSettings.next();
+      this.handleCloseFile(fileContext);
+      let nextFileContext = this.editorControl.fetchActiveFile();
+      this.selectFile(nextFileContext, true);
+    } else {
+      this.codeEditorService.closeFile(fileContext);
+    }
   }
 
   /* 
@@ -240,14 +297,22 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
      which kicks off discovery involving the editor controller   
   */
   selectFile(fileContext: ProjectContext, broadcast: boolean, line?: number) {
-    this.codeEditorService.selectFile(fileContext, broadcast);
+    if (fileContext.type != ProjectContextType.menu) { //TODO revisit for other types
+      this.showSettings = false;
+      this.codeEditorService.selectFile(fileContext, broadcast);
+    } else {
+      this.showSettings = true;
+      this.editorControl.selectMenu.next(fileContext);
+    }
     this.editorFile = { context: fileContext, reload: false, line: line };
     this.updateEditorTitle();
   }
 
   refreshFile(fileContext: ProjectContext, broadcast: boolean, line?: number) {
-    this.monacoService.refreshFile(fileContext, broadcast, line)
-    // We don't want to kick off openfile from the editor controller, so talk to monaco directly
+    if (fileContext.type != ProjectContextType.menu) { //TODO revisit for other types
+      this.monacoService.refreshFile(fileContext, broadcast, line)
+      // We don't want to kick off openfile from the editor controller, so talk to monaco directly
+    }
   }
 
   setTitle(title?:String):void {

--- a/webClient/src/app/editor/code-editor/code-editor.module.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.module.ts
@@ -11,9 +11,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { MatIconModule, MatDialogModule } from '@angular/material';
+import { MatDialogModule, MatSelectModule, MatButtonModule, MatInputModule, MatIconModule, MatCheckboxModule } from '@angular/material';
 
 import { MonacoComponent } from './monaco/monaco.component';
+import { MonacoSettingsComponent } from './monaco-settings/monaco-settings.component';
 import { MonacoService } from './monaco/monaco.service';
 import { CodeEditorComponent } from './code-editor.component';
 import { FileTabsComponent, MouseMiddleClickDirective } from './file-tabs/file-tabs.component';
@@ -28,6 +29,10 @@ import { LoadingIndicatorComponent } from './loading-indicator/loading-indicator
     FormsModule,
     MatIconModule,
     MatDialogModule,
+    MatButtonModule,
+    MatSelectModule,
+    MatInputModule,
+    MatCheckboxModule,
     PerfectScrollbarModule,
   ],
   providers: [MonacoService, CodeEditorService],
@@ -37,6 +42,7 @@ import { LoadingIndicatorComponent } from './loading-indicator/loading-indicator
     FileTabsComponent,
     LoadingIndicatorComponent,
     MonacoComponent,
+    MonacoSettingsComponent,
     MouseMiddleClickDirective,
   ]
 })

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.html
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.html
@@ -41,18 +41,16 @@
       </div>
     </div>
     <div class="button-row">
-      <button mat-raised-button class="menu-button" (click)="applyToPreview()">Preview</button>
-      <button mat-raised-button class="menu-button" color="warn" (click)="resetToDefault()">Reset to default</button>
-    </div>
-    <div class="button-row">
+      <button mat-raised-button class="menu-button" color="warn" (click)="resetEditor()">Reset</button>
       <button mat-raised-button class="menu-button" color="primary" (click)="commitToConfigService()">Save</button>
     </div>
   </div>
   <div class="preview">
-    <h2>JSON Preview</h2>
-    <mat-form-field class="form-field" style="height: 100%">
-      <textarea matInput placeholder="Monaco JSON Preview" [(ngModel)]="jsonText"></textarea>
-    </mat-form-field>
+    <h2 style="padding: 0.5em">JSON Preview</h2>
+    <div class="monaco-editor-preview" #monacoPreview></div>
+    <div class="button-row">
+      <button mat-raised-button class="menu-button" (click)="updateFromPreview()">Preview</button>
+    </div>
   </div>
 </div>
 <!--

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.html
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.html
@@ -1,0 +1,84 @@
+
+<!-- 
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+  -->
+<div class="outer">
+  <div class="container">
+    <h2>Editor Settings</h2>
+    <div class="scrolling-list">
+      <div *ngFor="let item of items; index as i">
+        <div style="display: flex; margin: 10px 0px 10px 0px" *ngIf="isTypeDropdown(item.type)">
+          <mat-form-field class="form-field">
+            <mat-label style="margin-right: 10px">{{getName(item)}}</mat-label>
+            <mat-select disableRipple="true" [(value)]="items[i].value" (selectionChange)="update(item)">
+              <mat-option *ngFor="let value of items[i].values; index as j" [value]="items[i].values[j]">
+                {{item.types[j]}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+        <div *ngIf="isTypeNumber(item.type)">
+          <mat-form-field class="form-field">
+            <mat-label>{{getName(item)}}</mat-label>
+            <input matInput type="number" placeholder="item.default" [(ngModel)]="item.value" (ngModelChange)="update(item)">
+          </mat-form-field>
+        </div>
+        <div *ngIf="isTypeString(item.type)">
+          <mat-form-field class="form-field">
+            <mat-label>{{getName(item)}}</mat-label>
+            <input matInput type="text" placeholder="item.default" [(ngModel)]="item.value" (ngModelChange)="update(item)">
+          </mat-form-field>
+        </div>
+        <div *ngIf="isTypeToggle(item.type)">
+          <mat-checkbox disableRipple="true" labelPosition="before" [(ngModel)]="items[i].value" (change)="update(item)">{{getName(items[i])}}</mat-checkbox>
+        </div>
+        <br>
+      </div>
+    </div>
+    <div class="button-row">
+      <button mat-raised-button class="menu-button" (click)="applyToPreview()">Preview</button>
+      <button mat-raised-button class="menu-button" color="warn" (click)="resetToDefault()">Reset to default</button>
+    </div>
+    <div class="button-row">
+      <button mat-raised-button class="menu-button" color="primary" (click)="commitToConfigService()">Save</button>
+    </div>
+  </div>
+  <div class="preview">
+    <h2>JSON Preview</h2>
+    <mat-form-field class="form-field" style="height: 100%">
+      <textarea matInput placeholder="Monaco JSON Preview" [(ngModel)]="jsonText"></textarea>
+    </mat-form-field>
+  </div>
+</div>
+<!--
+<mat-dialog-content>
+  <p> <b>{{data.fileName}}</b> is currently untagged. Please select a tag for it in USS. </p>
+  Encoding:
+  <mat-form-field>
+    <mat-select placeholder="Select An Encoding" [(ngModel)]="results.encoding">
+      <mat-option *ngFor="let option of options" [value]="option">
+      {{option}}</mat-option>
+    </mat-select>
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button mat-dialog-close class="right">Cancel</button>
+// The mat-dialog-close directive optionally accepts a value as a result for the dialog.
+  <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="results">Save</button>
+</mat-dialog-actions>
+-->
+
+<!-- 
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+-->

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.html
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.html
@@ -54,23 +54,6 @@
     </div>
   </div>
 </div>
-<!--
-<mat-dialog-content>
-  <p> <b>{{data.fileName}}</b> is currently untagged. Please select a tag for it in USS. </p>
-  Encoding:
-  <mat-form-field>
-    <mat-select placeholder="Select An Encoding" [(ngModel)]="results.encoding">
-      <mat-option *ngFor="let option of options" [value]="option">
-      {{option}}</mat-option>
-    </mat-select>
-  </mat-form-field>
-</mat-dialog-content>
-<mat-dialog-actions>
-  <button mat-button mat-dialog-close class="right">Cancel</button>
-// The mat-dialog-close directive optionally accepts a value as a result for the dialog.
-  <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="results">Save</button>
-</mat-dialog-actions>
--->
 
 <!-- 
   This program and the accompanying materials are

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.html
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.html
@@ -41,7 +41,7 @@
       </div>
     </div>
     <div class="button-row">
-      <button mat-raised-button class="menu-button" color="warn" (click)="resetEditor()">Reset</button>
+      <button mat-raised-button class="menu-button" color="warn" (click)="resetToDefault()">Defaults</button>
       <button mat-raised-button class="menu-button" color="primary" (click)="commitToConfigService()">Save</button>
     </div>
   </div>
@@ -49,6 +49,7 @@
     <h2 style="padding: 0.5em">JSON Preview</h2>
     <div class="monaco-editor-preview" #monacoPreview></div>
     <div class="button-row">
+      <button mat-raised-button class="menu-button" (click)="resetEditor()">Revert</button>
       <button mat-raised-button class="menu-button" (click)="updateFromPreview()">Preview</button>
     </div>
   </div>

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.scss
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.scss
@@ -43,7 +43,7 @@ mat-dialog-actions {
 }
 
 .monaco-editor-preview {
-    width: 100%;
+    width: calc(100%);
     height: calc(100% - 6.25em);
 }
 

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.scss
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.scss
@@ -22,12 +22,15 @@ mat-dialog-actions {
     height: 100%;
     max-width: 24em;
     text-align: right;
-    display: flex;
     flex-direction: column;
+    display: flex;
 }
 
 .preview {
     flex: auto;
+    display: flex;
+    border-left: ridge;
+    flex-direction: column;
 }
 
 .button-row {
@@ -37,6 +40,11 @@ mat-dialog-actions {
 .menu-button {
     margin: 0.5em;
     flex: auto;
+}
+
+.monaco-editor-preview {
+    width: 100%;
+    height: calc(100% - 6.25em);
 }
 
 .scrolling-list {

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.scss
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.scss
@@ -1,0 +1,58 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+mat-dialog-actions {
+    justify-content: flex-end;
+}
+
+.outer {
+    height: 100%;
+    background-color: #ffffff;
+    display: flex;
+}
+
+.container {
+    height: 100%;
+    max-width: 24em;
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+}
+
+.preview {
+    flex: auto;
+}
+
+.button-row {
+    display: flex;
+}
+
+.menu-button {
+    margin: 0.5em;
+    flex: auto;
+}
+
+.scrolling-list {
+    overflow-y: scroll;
+    overflow-x: hidden;
+}
+
+.form-field {
+    width: 100%;
+}
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.spec.ts
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.spec.ts
@@ -1,0 +1,45 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SettingsMenuComponent } from './settings-menu.component';
+
+describe('SettingsMenuComponent', () => {
+  let component: SettingsMenuComponent;
+  let fixture: ComponentFixture<SettingsMenuComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SettingsMenuComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SettingsMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.spec.ts
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.spec.ts
@@ -10,21 +10,21 @@
 */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { SettingsMenuComponent } from './settings-menu.component';
+import { MonacoSettingsComponent } from './monaco-settings.component';
 
-describe('SettingsMenuComponent', () => {
-  let component: SettingsMenuComponent;
-  let fixture: ComponentFixture<SettingsMenuComponent>;
+describe('MonacoSettingsComponent', () => {
+  let component: MonacoSettingsComponent;
+  let fixture: ComponentFixture<MonacoSettingsComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SettingsMenuComponent ]
+      declarations: [ MonacoSettingsComponent ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(SettingsMenuComponent);
+    fixture = TestBed.createComponent(MonacoSettingsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.ts
@@ -120,9 +120,12 @@ export class MonacoSettingsComponent implements OnInit {
         this.config = response.contents.config;
         this.jsonText = this.configToText();
         this.setConfigFromJson();
+        this.updateEditor();
       } else {
+        this.resetUI();
         this.initConfig();
         this.jsonText = this.configToText();
+        this.updateEditor();
       }
     },
     //in case of error, just default                                                                                                                                            
@@ -167,7 +170,6 @@ export class MonacoSettingsComponent implements OnInit {
 
   resetEditor() {
     this.setConfigFromConfigService();
-    this.updateEditor();
   }
   
   update(item: MonacoConfigItem) {

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.ts
@@ -61,7 +61,7 @@ export class MonacoSettingsComponent implements OnInit {
 
   private resetToDefault() {
     this.http.delete<any>(ZoweZLUX.uriBroker.pluginConfigForScopeUri(this.pluginDefinition.getBasePlugin(),'user','monaco','editorconfig.json')).subscribe((response: any) => {
-      this.log.info('Delete complete');
+      this.log.info('Restored editor defaults by removing old configuration');
       this.resetUI();
       this.initConfig();
       this.jsonText = this.configToText();
@@ -212,9 +212,6 @@ export class MonacoSettingsComponent implements OnInit {
       }
       this.editor.setModel(this.editorModel);
       this.updateEditor();
-//      let models = this.editor._modelData.model;
-//      console.log('model',models);
-//      this.models.setModelLanguage(models,'json');
     },500);
     
   }
@@ -228,7 +225,7 @@ export class MonacoSettingsComponent implements OnInit {
           "_metaDataVersion": "1.0.0",
           "config": this.config
         }).subscribe((result: any)=> {
-        this.log.info('Save return');
+        this.log.debug('Settings store success');
     });
     this.options.next(this.config);
   }

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.component.ts
@@ -1,0 +1,154 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+import { Component, OnInit, Inject, EventEmitter } from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {Observable} from 'rxjs';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
+import { DEFAULT_CONFIG, MonacoConfigItem, ConfigItemType } from '../monaco/monaco.config';
+
+function getValueNameFromValue(value: string) {
+  if (typeof value != 'string') {
+    return ''+value;
+  }
+  let out = value.charAt(0).toUpperCase();
+  for (let i = 1; i < value.length; i++) {
+    if (value.charCodeAt(i) >= 0x41 && value.charCodeAt(i) <= 0x5a) {
+      out+=' '+value.charAt(i);
+    } else {
+      out+=value.charAt(i);
+    }
+  }
+  return out;
+}
+
+function getValueNames(values: string[]) {
+  let names = [];
+  values.forEach((value:any)=> {
+    names.push(getValueNameFromValue(value));
+  });
+  return names;
+}
+
+
+@Component({
+  selector: 'app-monaco-settings',
+  templateUrl: './monaco-settings.component.html',
+  styleUrls: ['./monaco-settings.component.scss',  '../../../../styles.scss']
+})
+export class MonacoSettingsComponent {
+  resetToDefault() {
+    let items = [];
+    DEFAULT_CONFIG.forEach((item)=> {
+      let newItem:MonacoConfigItem = Object.assign({},item);
+      if (newItem.values) {
+        newItem.types = getValueNames(newItem.values);
+      }
+      newItem.value = newItem.default;
+      items.push(newItem);
+    });
+    this.items = items;
+  }
+
+  private initConfig() {
+    this.config = {};
+    DEFAULT_CONFIG.forEach((item)=> {
+      this.setConfig(item.attribute, undefined, item.default);
+    });
+  }
+
+  public config:any;
+  public jsonText:string;
+  public items: MonacoConfigItem[];
+  
+  constructor(
+    @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger,
+    @Inject(Angular2InjectionTokens.PLUGIN_DEFINITION) private pluginDefinition: ZLUX.ContainerPluginDefinition,
+    private http: HttpClient
+  ) {
+    this.resetToDefault();
+    this.initConfig();
+    this.jsonText = this.configToText();
+  }
+
+  setConfig(attribute: string, value?: any, defaultValue?: any) {
+    let val = value ? value : defaultValue;
+    let parts = attribute.split('.');
+    let parentObj = {};
+    let lastObj = parentObj;
+    let currentObj = parentObj;
+    let pos = 0;
+    while (pos < parts.length) {
+      let newObj = {};
+      currentObj[parts[pos]] = newObj;
+      lastObj = currentObj;
+      currentObj = newObj;
+      pos++;
+    }
+    lastObj[parts[parts.length-1]] = val;
+    this.config = Object.assign(this.config, parentObj);
+    
+  }
+
+  update(item: MonacoConfigItem) {
+    this.log.info('monaco config update item=%s, value=%s',item.attribute, item.value);
+    this.setConfig(item.attribute, item.value, item.default);
+    this.jsonText = this.configToText();
+  }
+  
+  ngOnInit() {
+  }
+
+  commitToConfigService() {
+    this.http.put(ZoweZLUX.uriBroker.pluginConfigForScopeUri(this.pluginDefinition.getBasePlugin(), 'user', 'monaco', 'editorconfig.json'),
+        {
+          "_objectType": "org.zowe.zlux.editor.monaco.editor.config",
+          "_metaDataVersion": "1.0.0",
+          "config": this.config
+        }).subscribe((result: any)=> {
+        this.log.info('Save return');
+    });
+  }
+  
+  public isTypeDropdown(type: number) {
+    return type == ConfigItemType.array
+  }
+  public isTypeNumber(type: number) {
+    return type == ConfigItemType.number
+  }
+  public isTypeString(type: number) {
+    return type == ConfigItemType.string
+  }
+  public isTypeToggle(type: number) {
+    return type == ConfigItemType.boolean
+  }
+
+  public getName(item: MonacoConfigItem) {
+    return getValueNameFromValue(item.attribute);
+  }
+
+  configToText() {
+    return JSON.stringify(this.config,null,2);
+  }
+
+  textToConfig(text: string) {
+    this.config = JSON.parse(text);
+  }
+}
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/

--- a/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco-settings/monaco-settings.config.ts
@@ -1,0 +1,9 @@
+export class MonacoEditorConfig {
+  constructor(
+    public _objectType: string,
+    public _metadataVersion: string,
+    public contents: any
+  ) {
+
+  }
+}

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
@@ -36,7 +36,6 @@ export class MonacoComponent implements OnInit, OnChanges {
     if (!options) {return;}
     this._options = options;
     if (this.editor) {
-      console.log(this.editor);
       if (options.theme) {
         this.editorControl._setDefaultTheme(options.theme);
         try {

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
@@ -41,10 +41,10 @@ export class MonacoComponent implements OnInit, OnChanges {
         this.editorControl._setDefaultTheme(options.theme);
         try {
           this.editor._themeService.setTheme(options.theme);
+          this.log.info("Updated monaco theme");
         } catch (e) {
           this.log.warn("Monaco _themeService.setTheme could not be called");
         }
-        this.log.info("Updated monaco theme");
       }
       
       this.editor.updateOptions(options);
@@ -84,6 +84,9 @@ export class MonacoComponent implements OnInit, OnChanges {
     }
     this.log.info("Creating new editor with options=",options);
     let editor = monaco.editor.create(this.monacoEditorRef.nativeElement, options);
+    if (options.theme) {
+      this.editorControl._setDefaultTheme(options.theme);
+    }
     if (!hasModel) {
       editor.setValue('');
     }
@@ -98,6 +101,10 @@ export class MonacoComponent implements OnInit, OnChanges {
   focus(e: any) {
     this.editor.focus();
   }
+  layout(e: any) {
+    this.editor.layout();
+  }
+
 
   ngOnChanges(changes: SimpleChanges) {
     for (const input in changes) {

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
@@ -41,16 +41,14 @@ export class MonacoComponent implements OnInit, OnChanges {
         this.editorControl._setDefaultTheme(options.theme);
         try {
           this.editor._themeService.setTheme(options.theme);
-          this.log.info("Updated monaco theme");
         } catch (e) {
           this.log.warn("Monaco _themeService.setTheme could not be called");
         }
       }
       
       this.editor.updateOptions(options);
-      this.log.info("Updated monaco with options");
     } else {
-      this.log.info("Editor options passed prior to editor init. Cached.");
+      this.log.debug("Editor options passed prior to editor init. Cached.");
     }
   };
   
@@ -82,7 +80,7 @@ export class MonacoComponent implements OnInit, OnChanges {
         options.model = monaco.editor.createModel(options.model.value, options.model.language, options.model.uri);
       }
     }
-    this.log.info("Creating new editor with options=",options);
+    this.log.debug("New editor with options=",options);
     let editor = monaco.editor.create(this.monacoEditorRef.nativeElement, options);
     if (options.theme) {
       this.editorControl._setDefaultTheme(options.theme);

--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -181,12 +181,12 @@ export const DEFAULT_CONFIG: MonacoConfigItem[] = [
     {
       attribute: 'fontFamily',
       type: ConfigItemType.string,
-      default: ''
+      default: undefined
     },
     {
       attribute: 'fontSize',
       type: ConfigItemType.number,
-      default: -1
+      default: undefined
     },
     {
       attribute: 'formatOnPaste',

--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -98,10 +98,328 @@ export const REXX_DARK: Theme = {
 	]
 }
 
+export enum ConfigItemType {
+  array = 0,
+  number = 1,
+  string = 2,
+  boolean = 3
+}
+
+export type MonacoConfigItem = {
+  attribute: string;
+  defaultName?: string;
+  type: ConfigItemType;
+  types?: string[];
+  values?: any[];
+  value?: any;
+  default: any;
+}
+
+export const DEFAULT_CONFIG: MonacoConfigItem[] = [
+    {
+      attribute: 'theme',
+      type: ConfigItemType.array,
+      values: ['vs', 'vs-dark'],
+      default: 'vs-dark'
+    },
+    {
+      attribute: 'autoClosingBrackets',
+      type: ConfigItemType.array,
+      values: ['always', 'languageDefined', 'beforeWhitespace', 'never'],
+      default: 'languageDefined'
+    },
+    {
+      attribute: 'autoClosingOvertype',
+      type: ConfigItemType.array,
+      values: ['always', 'auto', 'never'],
+      default: undefined
+    },
+    {
+      attribute: 'autoClosingQuotes',
+      type: ConfigItemType.array,
+      values: ['always', 'languageDefined', 'beforeWhitespace', 'never'],
+      default: 'languageDefined'
+    },
+    {
+      attribute: 'autoIndent',
+      type: ConfigItemType.array,
+      values: ['none', 'keep', 'brackets', 'advanced', 'full'],
+      default: 'advanced'
+    },
+    {
+      attribute: 'codeLens',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'colorDecorators',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'codeBlinking',
+      type: ConfigItemType.array,
+      values: ['blink','smooth','phase','expand','solid'],
+      default: 'blink'
+    },
+    {
+      attribute: 'cursorStyle',
+      type: ConfigItemType.array,
+      values: ['line','block','underline','line-thin','block-outline','underline-thin'],
+      default: 'line'
+    },
+    {
+      attribute: 'folding',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'foldingHighlight',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'fontFamily',
+      type: ConfigItemType.string,
+      default: ''
+    },
+    {
+      attribute: 'fontSize',
+      type: ConfigItemType.number,
+      default: -1
+    },
+    {
+      attribute: 'formatOnPaste',
+      type: ConfigItemType.boolean,
+      default: false
+    },
+    {
+      attribute: 'formatOnType',
+      type: ConfigItemType.boolean,
+      default: false
+    },
+    {
+      attribute: 'hover.delay',
+      type: ConfigItemType.number,
+      default: 300
+    },
+    {
+      attribute: 'hover.enabled',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'lineNumbers',
+      type: ConfigItemType.array,
+      values: ['on','off','relative','interval'],
+      default: 'on'
+    },
+    {
+      attribute: 'links',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'matchBrackets',
+      type: ConfigItemType.array,
+      values: ['never','near','always'],
+      default: 'always'
+    },
+    {
+      attribute: 'minimap.enabled',
+      type: ConfigItemType.boolean,
+      default: false
+    },
+    {
+      attribute: 'minimap.maxColumn',
+      type: ConfigItemType.number,
+      default: 120
+    },
+    {
+      attribute: 'minimap.side',
+      type: ConfigItemType.array,
+      values: ['left','right'],
+      default: 'right'
+    },
+    {
+      attribute: 'occurrencesHighlight',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'parameterHints.enabled',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'quickSuggestions',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'quickSuggestionsDelay',
+      type: ConfigItemType.number,
+      default: 10
+    },
+    {
+      attribute: 'renderControlCharacters',
+      type: ConfigItemType.boolean,
+      default: false
+    },
+    {
+      attribute: 'renderFinalNewline',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'renderIndentGuides',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'renderLineHighlight',
+      type: ConfigItemType.array,
+      values: ['none','gutter','line','all'],
+      default: 'all'
+    },
+    {
+      attribute: 'renderLineHighlightOnlyWhenFocus',
+      type: ConfigItemType.boolean,
+      default: false
+    },
+    {
+      attribute: 'renderValidationDecorations',
+      type: ConfigItemType.array,
+      values: ['editable','on','off'],
+      default: 'editable'
+    },
+    {
+      attribute: 'renderWhitespace',
+      type: ConfigItemType.array,
+      values: ['none','boundary','selection','trailing','all'],
+      default: 'none'
+    },
+    {
+      attribute: 'roundedSelection',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'ruler[0]',
+      type: ConfigItemType.number,
+      default: 0
+    },
+    {
+      attribute: 'scrollBeyondLastColumn',
+      type: ConfigItemType.number,
+      default: 5
+    },
+    {
+      attribute: 'scrollBeyondLastLine',
+      type: ConfigItemType.boolean,
+      default: false
+    },
+    {
+      attribute: 'selectOnLineNumbers',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'selectionHighlight',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'showDeprecated',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'showFoldingControls',
+      type: ConfigItemType.array,
+      values: ['always', 'mouseover'],
+      default: 'mouseover'
+    },
+    {
+      attribute: 'showUnused',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'smoothScrolling',
+      type: ConfigItemType.boolean,
+      default: false
+    },
+    {
+      attribute: 'snippetSuggestions',
+      type: ConfigItemType.array,
+      values: ['top','bottom','inline','none'],
+      default: true
+    },
+    {
+      attribute: 'stickyTabStops',
+      type: ConfigItemType.boolean,
+      default: false
+    },
+    {
+      attribute: 'stopRenderingLineAfter',
+      type: ConfigItemType.number,
+      default: 10000
+    },
+    {
+      attribute: 'suggestOnTriggerCharacters',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'suggestSelection',
+      type: ConfigItemType.array,
+      values: ['first','recentlyUsed','recentlyUsedByPrefix'],
+      default: undefined
+    },
+    {
+      attribute: 'tabCompletion',
+      type: ConfigItemType.array,
+      values: ['on','off','onlySnippets'],
+      default: undefined
+    },
+    {
+      attribute: 'unfoldOnClickAfterEndOfLine',
+      type: ConfigItemType.boolean,
+      default: false
+    },
+    {
+      attribute: 'useTabStops',
+      type: ConfigItemType.boolean,
+      default: false
+    },
+    {
+      attribute: 'wordSeparators',
+      type: ConfigItemType.string,
+      default: '`~!@#$%^&*()-=+[{]}\|;:\'",.<>/?'
+    },
+    {
+      attribute: 'wordWrap',
+      type: ConfigItemType.array,
+      values: ['off','on','wordWrapColumn','bounded'],
+      default: 'off'
+    },
+    {
+      attribute: 'wordWrapColumn',
+      type: ConfigItemType.number,
+      default: 80
+    },
+    {
+      attribute: 'wrappingIndent',
+      type: ConfigItemType.array,
+      values: ['none','same','indent','deepIndent'],
+      default: 'none'
+    }
+];
+
 
 export class MonacoConfig {
   subscription: Subscription = null;
-  defaultOptions: any = { scrollBeyondLastLine: false }; // pass default options to be used
 
   onLoad() {
     let self = this;

--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -305,11 +305,6 @@ export const DEFAULT_CONFIG: MonacoConfigItem[] = [
       default: true
     },
     {
-      attribute: 'ruler[0]',
-      type: ConfigItemType.number,
-      default: 0
-    },
-    {
       attribute: 'scrollBeyondLastColumn',
       type: ConfigItemType.number,
       default: 5

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -58,7 +58,6 @@ export class MonacoService {
         // get monaco modal
         const _context: ProjectContext = e.context;
         const _editor = this.editorControl.editorCore.getValue().editor;
-        console.log('editor=',_editor);
         const _modal = _editor.getModel(this.generateUri(_context.model));
 
         _context.model.language = e.language;

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -58,6 +58,7 @@ export class MonacoService {
         // get monaco modal
         const _context: ProjectContext = e.context;
         const _editor = this.editorControl.editorCore.getValue().editor;
+        console.log('editor=',_editor);
         const _modal = _editor.getModel(this.generateUri(_context.model));
 
         _context.model.language = e.language;

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -63,7 +63,10 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   public changeLanguage: EventEmitter<{ context: ProjectContext, language: string }> = new EventEmitter();
   public connToLS: EventEmitter<string> = new EventEmitter();
   public disFromLS: EventEmitter<string> = new EventEmitter();
-
+  public openSettings: EventEmitter<void> = new EventEmitter(); //open settings menu, a menu-type projectcontext
+  public closeSettings: EventEmitter<void> = new EventEmitter(); 
+  public selectMenu: EventEmitter<ProjectContext> = new EventEmitter(); //select menu-type projectcontext
+  
   private _rootContext: BehaviorSubject<ProjectContext> = new BehaviorSubject<ProjectContext>(undefined);
   private _context: BehaviorSubject<ProjectContext[]> = new BehaviorSubject<ProjectContext[]>(undefined);
   private _projectNode: BehaviorSubject<ProjectStructure[]> = new BehaviorSubject<ProjectStructure[]>(undefined);

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -70,6 +70,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   private _editorCore: BehaviorSubject<any> = new BehaviorSubject<any>(undefined);
   private _editor: BehaviorSubject<any> = new BehaviorSubject<any>(undefined);
   private _openFileList: BehaviorSubject<ProjectContext[]> = new BehaviorSubject<ProjectContext[]>([]);
+  private _defaultTheme: string;
 
   private _projectName = '';
   public _isTestLangMode = false;
@@ -929,6 +930,10 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
     this.changeLanguage.next({ context: buffer, language: language });
   }
 
+  _setDefaultTheme(theme: string) {
+    this._defaultTheme = theme;
+  }
+
   /**
    * Sets the theme for a unique language, if necessary.
    *
@@ -950,9 +955,10 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
         monaco.editor.setTheme('rexx-dark');
         break; 
       }
-      default: { 
-        // TODO: Once we expand editor themes, this will be set by for ex. getDefaultTheme() instead
-        monaco.editor.setTheme('vs-dark');
+      default: {
+        if (this._defaultTheme) {
+          monaco.editor.setTheme(this._defaultTheme);
+        }
         break; 
       } 
     } 

--- a/webClient/src/app/shared/model/project-context.ts
+++ b/webClient/src/app/shared/model/project-context.ts
@@ -10,6 +10,11 @@
 */
 import { ProjectStructure } from './editor-project';
 
+export enum ProjectContextType {
+  file = 0,
+  menu = 1
+}
+
 export interface ProjectContext {
     id: string;
     name: string;
@@ -22,6 +27,7 @@ export interface ProjectContext {
     children?: ProjectContext[];
     temp?: boolean;
     tempChildren?: ProjectContext[];
+    type?: ProjectContextType;
 }
 
 /*

--- a/webClient/tsconfig.json
+++ b/webClient/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "../../zlux-app-manager/virtual-desktop/plugin-config/tsconfig.base.json",
+  "include": [
+    "src/**/*.ts",
+    "../../zlux-platform/interface/src/mvd-hosting.d.ts"
+  ],
   "exclude": [
     "test.ts",
     "**/*.spec.ts"


### PR DESCRIPTION
Initial settings menu which allows for customization of builtin monaco features such as the theme, font, and text behavior.
This creates a new menu item "edit" which has the submenu "preferences".
This opens up a tab which is for editing preferences of monaco, and you will see various properties which you can control by input boxes and dropdowns.
There's 3 buttons on this menu: 
* save which saves to the config service (and applies to the editor right away, and the editor uses these settings on startup)
* preview, which takes whatever json is in the text preview area and tries to apply it, if its valid
* reset, which gets the data from the config service again, in case you didnt like your changes.
