### PR TITLE
enable the save button only when fileName, Directory and Encoding have values

### DIFF
--- a/webClient/src/app/shared/dialog/save-to/save-to.component.html
+++ b/webClient/src/app/shared/dialog/save-to/save-to.component.html
@@ -32,7 +32,7 @@
 <mat-dialog-actions>
   <button mat-button mat-dialog-close class="right">Cancel</button>
   <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
-  <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="results">Save</button>
+  <button mat-button mat-stroked-button class="right" color="primary" [mat-dialog-close]="results" [disabled]="!results.fileName || !results.directory || !results.encoding">Save</button>
 </mat-dialog-actions>
 
 <!-- 


### PR DESCRIPTION
enable the save button only when fileName, Directory and Encoding have values
Signed-off-by: Adarshdeep Cheema <adarshdeep.cheema@ibm.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
The value was getting selected from the select drop-down, without any issue, however, the selected value was not visible against the white background as the selected text was white. 
Fix: changing the selected text font color from white to black, to make it visible when a value is selected from the select dropdown


This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]
https://github.com/zowe/zlux/issues/234
This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
