### PR TITLE
Maintaining the mouse cursor in the editor while switching tabs

### DIFF
--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -144,8 +144,10 @@ export class MonacoService {
     reload - Tells Editor to reload file language settings & other file init actions
    */
   openFile(fileNode: ProjectContext, reload: boolean, line?: number) {
-    this.editorControl.saveCursorState();
     if (fileNode.temp) {
+      if(!this.editorControl.isFileClosed) {  
+        this.editorControl.selectFileHandler(fileNode);
+      }
       //blank new file
       this.setMonacoModel(fileNode, <{ contents: string, language: string }>{ contents: '', language: '' }, true).subscribe(() => {
         this.editorControl.fileOpened.next({ buffer: fileNode, file: fileNode.name });
@@ -195,6 +197,8 @@ export class MonacoService {
           }
         }
       });
+    // this.editorControl.saveCursorState();
+    this.editorControl.selectFileHandler(fileNode);
     }
   }
 
@@ -266,6 +270,7 @@ export class MonacoService {
     for (const model of models) {
       if (model.uri === fileUri) {
         model.dispose();
+        this.editorControl.isFileClosed = true;
       }
     }
   }

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -83,7 +83,7 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   /* TODO: This can be extended to persist in future server storage mechanisms. 
   (For example, when a user re-opens the Editor they are plopped back into their workflow of tabs) */
   private previousSessionData: any = {};
-
+  public isFileClosed = false; 
 
   /**
    * An event that is triggered when a file is opened inside the editor.
@@ -118,6 +118,15 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
 
   public saveCursorState() {
     let editor = this.editor.getValue();
+    this.editor.subscribe((value)=> {
+      if (value) {
+        if(!value._modelData) {
+          return;
+        }
+        editor.cursor = value._modelData.cursor;
+        editor.viewModel = value._modelData.viewModel;
+      } 
+    });  
     //when quickly switching, cursor or viewmodel may not exist
     if (editor && editor.cursor && editor.viewModel && lastFile) {
       let lastCursor = editor.cursor.saveState();
@@ -291,7 +300,10 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   }
 
   public selectFileHandler(fileContext: ProjectContext) {
-    this.saveCursorState();
+    if(!this.isFileClosed) {  
+      this.saveCursorState();
+    }
+    // this.saveCursorState();
     //fileopen to be called soon after
     let fileOpenSub: Subscription = this.fileOpened.subscribe((e: ZLUX.EditorFileOpenedEvent) => {
       let model = e.buffer.model;
@@ -300,9 +312,16 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
       this.log.debug(`restoring cache`,cache,`file`,lastFile);
       if (cache){
         let editor = this.editor.getValue();
-        editor.cursor.restoreState(cache.cursor);
-        const smallView = editor.viewModel.reduceRestoreState(cache.view);
-			  editor._view.restoreState(smallView);
+        this.editor.subscribe((value)=> {
+          if(value._modelData) {
+            editor.cursor = value._modelData.cursor;
+            editor.viewModel = value._modelData.viewModel;
+            editor._view = value._modelData.view
+            editor.cursor.restoreState(cache.cursor);
+            const smallView = editor.viewModel.reduceRestoreState(cache.view);
+            editor._view.restoreState(smallView);
+          }
+        })  
       }
       this.checkForAndSetReadOnlyMode(model);
       fileOpenSub.unsubscribe();
@@ -733,7 +752,6 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   }
 
   createFile(name?: string): ProjectContext {
-
     if(name===undefined) {
       name = this.getNewFileName();
     }
@@ -824,10 +842,13 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
      */
   openFile(file: string, targetBuffer: ZLUX.EditorBufferHandle | null): Observable<ZLUX.EditorBufferHandle> {
     // targetBuffer is a context of project in GCE.
+    this.openFileList.subscribe((list: ProjectContext[]) => {
+      list.length === 1 ? this.isFileClosed = true : this.isFileClosed = false;
+    });
     let resultOpenObs: Observable<ZLUX.EditorBufferHandle>;
     let fileOpenSub: Subscription;
     let resultObserver: Observer<ZLUX.EditorBufferHandle>;
-    this.saveCursorState();
+    // this.saveCursorState();
     
     resultOpenObs = new Observable((observer) => {
       resultObserver = observer;


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
Issue- Maintaining mouse cursor in the editor while switching tab.

Previously the editor was not able to the locate the cursor and the view model. Hence the state of the cursor was not saved.
Due to this editor was basically scrolling to the beginning of the file (and place the cursor there) every time you switch the tabs.

After the changes the editor is able to store the cursor's state before switching the tabs.
