### PR TITLE
Made error handling and UX better for DS not opened case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Zlux Editor Changelog
 
 ## `2.8.0`
+- Bugfix: Fixed error message & phantom tab when opening undefined length dataset
 - Added previously selected content comparison (Diff viewer)
 - Added the ability to refresh the file properties in File Tree, when an already exiting untagged file is saved with an encoding type.
 - Added the ability to use the latest USS encoding when saving an exiting file.

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -78,7 +78,7 @@ export class MonacoService implements OnDestroy {
         e.preventDefault();
         let fileContext = self.editorControl.fetchActiveFile();
         let directory = fileContext.model.path || self.editorControl.activeDirectory;
-        let sub = self.saveFile(fileContext, directory).subscribe(() => sub.unsubscribe());
+        let sub = self.saveFile(fileContext, directory).subscribe(() => {}, e => {}, () => {}); // Error handling is done up-stream
       }
     }
     document.addEventListener("keydown", this.fileSaveListener);
@@ -210,6 +210,7 @@ export class MonacoService implements OnDestroy {
           });
         },
         error: (err) => {
+          this.editorControl.closeFileHandler(fileNode);
           this.log.warn(`${fileNode.name} could not be opened, status: `, err.status);
           if (err.status === 403) {
             this.snackBar.open(`${fileNode.name} could not be opened due to permissions.`,
@@ -218,8 +219,9 @@ export class MonacoService implements OnDestroy {
             this.snackBar.open(`${fileNode.name} could not be found.`,
               'Close', { duration: MessageDuration.Medium, panelClass: 'center' });
           } else {
-            this.snackBar.open(`${fileNode.name} could not be opened.`,
-              'Close', { duration: MessageDuration.Medium, panelClass: 'center' });
+            let reason = err._body || "Not provided by agent";
+            this.snackBar.open(`${fileNode.name} could not be opened. Reason: ` + reason,
+              'Close', { duration: MessageDuration.Long, panelClass: 'center' });
           }
         }
       });

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -78,7 +78,7 @@ export class MonacoService implements OnDestroy {
         e.preventDefault();
         let fileContext = self.editorControl.fetchActiveFile();
         let directory = fileContext.model.path || self.editorControl.activeDirectory;
-        let sub = self.saveFile(fileContext, directory).subscribe(() => {}, e => {}, () => {}); // Error handling is done up-stream
+        let sub = self.saveFile(fileContext, directory).subscribe(() => sub.unsubscribe()); // Error handling is done up-stream
       }
     }
     document.addEventListener("keydown", this.fileSaveListener);


### PR DESCRIPTION
Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Makes message for when DS cannot be opened (due to undefined length dataset) better + closes the tab instead of leaving a phantom empty tab open

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

You need access to an undefined length dataset
