### PR TITLE
update changelog when its PR

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -34,6 +34,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   update-changelog:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       was_updated: ${{ steps.check-change.outputs.change_detected }}
@@ -109,6 +110,7 @@ jobs:
           fi
 
   check_changelog:
+    if: github.event_name == 'pull_request'
     needs: update-changelog
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - BugFix: Editor keeps the content of the file, after an opened file is closed.
 
 ## `2.9.0`
+
 - Added the feature to update the dataset in the editor
 - Added the check for e-tag while updating the dataset
 - Added feature to open a file in new broswer tab
@@ -26,6 +27,7 @@
 - Added the feature to prompt the user to save the unsaved files before closing
 
 ## `2.8.0`
+
 - Bugfix: Fixed error message & phantom tab when opening undefined length dataset
 - Bugfix: Unable to recalculate the size of monaco-code-container when switching from diff-viewer to code-editor.
 - Added previously selected content comparison (Diff viewer)


### PR DESCRIPTION
Small update in changelog action, it will check and update changelog when its a PR, Currently some builds show that they are failing because of the changelog, the changelog logic shouldn't run unless if its a pull request.