### PR TITLE
Re-enabled JCL submit in V2 + JES Explorer view job

### DIFF
--- a/webClient/src/app/core/menu-bar/menu-bar.config.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.config.ts
@@ -38,52 +38,59 @@ export const TEST_LANGUAGE_MENU = [{name:'TEST_REPLACE',
 export const LANGUAGE_MENUS = {
   'jcl': [
     {
-      name: 'Submit (Future)',
+      name: 'Submit',
       isDisabledString: `
       const plugin = ZoweZLUX.pluginManager.getPlugin('org.zowe.explorer-jes');
       const file = context.controller.fetchActiveFile();
     if (!plugin || !file || (ZoweZLUX.uriBroker.serverRootUri('') == '/')) {
         return true;
       }
-      return true;
-      ` /* CHANGEME TODO line above this comment should be "return false" once JCL submit works as intended */,
+      return false;
+      `,
       action: {
         /*
           TODO z/osmf has a jobs api, so this makes use of it for now. 
           But, we don't import that service into the editor, because it would make a hard requirement instead of an optional one.
           May want to have such metadata in plugindef, or perhaps this is an interface & capability to be searched up
+          note: content = context.editor.getValue(); because we submit editor wip content not saved-somewhere content
+          note: URL hits API ML base path. As API-ML is a hard requirement for Zowe, no need for ZoweURIBroker
+          but for dev, app-server only testing, prob need ZoweZLUX.uriBroker.serverRootUri('')
+          note: rawStream handling below can be used to read ReadableStream for debugging
         */
-        functionString:`
+        functionString: `
         const file = context.controller.fetchActiveFile();
+        const uri = '/ibmzosmf/api/v1/zosmf/restjobs/jobs/';
         if (file) {
-          let content = context.editor.model.getValue();
+          let content = context.editor.getValue();
           if (content && content.length > 0) {
-            content = content.replace(/\\n/g,'\\\\n');
-            const uri = '/api/v1/jobs/string';
-            const stringJsonBody = '{ "jcl": "'+content+'"}';  
-            fetch(uri, {method: 'POST', body: stringJsonBody,
+            fetch(uri, {method: 'PUT', body: content,
                         credentials: 'include',
                         mode: 'cors',
-                        headers:{ 'Content-Type': 'application/json'}})
-              .then((response)=> {
-                     if (!response.ok) {
+                        headers:{ 
+                          "Content-Type": "text/plain", 
+                          "X-CSRF-ZOSMF-HEADER": "true",
+                          "Accept": "application/json" }})
+              .then(async (response) => {
+                    // const rawStream = await response.clone().text();
+                    // console.log("Response body?", rawStream)
+                                   if (!response.ok) {
                        throw new Error('Status: '+response.status+', '+response.statusText);
                      } else {
                        return response.json();
                      }
-                   })
+              })
               .then((response)=> {
-                     if (response.jobId && response.owner) {
-                       file.model.jobId = response.jobId;
+                     if (response.jobid && response.owner) {
+                       file.model.jobid = response.jobid;
                        file.model.jobOwner = response.owner;
-                       let ref = context.controller.snackBar.open('JCL Submitted. ID='+response.jobId,'View in Explorer', {duration: 5000, panelClass: 'center' })
+                       let ref = context.controller.snackBar.open('JCL Submitted. ID='+response.jobid,'View in Explorer', {duration: 5000, panelClass: 'center' })
                          .onAction().subscribe(()=> {
                            const dispatcher = ZoweZLUX.dispatcher;
                            const argumentFormatter = {data: {op:'deref',source:'event',path:['data']}};
                            let action = dispatcher.makeAction('org.zowe.editor.jcl.view', 'View JCL',
                                                               dispatcher.constants.ActionTargetMode.PluginFindAnyOrCreate,
                                                               dispatcher.constants.ActionType.Launch,'org.zowe.explorer-jes',argumentFormatter);
-                           dispatcher.invokeAction(action,{'data':{'owner':file.model.jobOwner,'prefix':'*','jobId':file.model.jobId}});
+                           dispatcher.invokeAction(action,{'data':{'owner':file.model.jobOwner,'prefix':'*','jobId':file.model.jobid}});
                          });
                      } else {
                        context.controller.snackBar.open('Warning: JCL submitted but Job ID not found.', 'Dismiss', {duration: 5000, panelClass: 'center' });
@@ -101,7 +108,7 @@ export const LANGUAGE_MENUS = {
       name: 'group-end'
     },
     {
-      name: 'View Job (Future)',
+      name: 'View Job',
       isDisabledString: `
       const plugin = ZoweZLUX.pluginManager.getPlugin('org.zowe.explorer-jes');
       const file = context.controller.fetchActiveFile();


### PR DESCRIPTION
What did you change?

I re-enabled JCL submit in Editor V2 via top menu

What made it work?

- fix Editor runtime issue (in func eval)
- switch implementation to use correct z/OSMF APIs (w/ a change from json --> plain text)
- re-enable ability to view submitted job in JES Explorer (which we get for free - already worked, yay but wasn't exposed)

<img width="660" height="140" alt="image" src="https://github.com/user-attachments/assets/73afbf6b-ed76-4942-8b33-955622c1910a" />


<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [ ] DONE

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
