### PR TITLE
Add size limit for uss and mvs files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `3.5.0`
+
+- Enhancement: Added configurable file/dataset size limit (default 50MB) with a warning dialog and user override option to prevent high memory and CPU usage when opening very large files or datasets.
+
 ## `3.4.0`
 
 - Enhancement: Re-enabled JCL submit via submit menu and ability to view submitted job via JES Explorer desktop app.

--- a/config/storageDefaults/limits/limits.json
+++ b/config/storageDefaults/limits/limits.json
@@ -1,0 +1,6 @@
+{
+  "_metadataVersion": "1.1",
+  "_objectType": "org.zowe.editor.limits",
+  "maxFileSize": 50000000,
+  "folderMaxCount": 200
+}

--- a/config/storageDefaults/limits/limits.json
+++ b/config/storageDefaults/limits/limits.json
@@ -1,6 +1,6 @@
 {
   "_metadataVersion": "1.1",
   "_objectType": "org.zowe.editor.limits",
-  "maxFileSize": 50000000,
+  "maxFileSize": 52428800,
   "folderMaxCount": 200
 }

--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -36,6 +36,9 @@
       },
       "monaco": {
         "aggregationPolicy": "none"
+      },
+      "limits": {
+        "aggregationPolicy": "override"
       }
     }
   }

--- a/webClient/src/app/editor/code-editor/code-editor.component.ts
+++ b/webClient/src/app/editor/code-editor/code-editor.component.ts
@@ -274,9 +274,10 @@ export class CodeEditorComponent implements OnInit, OnDestroy {
       this.selectFile(fileContext, false, fileNode.line);
     } else {
       // pass file structure to specific code editor (monaco)
-      // trigger code-editor change, let code editor open file
+      // trigger code-editor change, let code editor open file.
+      // Note: openFileHandler (tab creation) is deferred to monacoService.openFile()
+      // so that large-file preflight checks run before the tab appears.
       this.editorFile = { context: fileContext, reload: true, line: fileContext.model.line || fileNode.line };
-      this.editorControl.openFileHandler(fileContext);
     }
 
   }

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -322,6 +322,7 @@ export class MonacoService implements OnDestroy {
     this.editorControl.selectFileHandler(fileNode);
     if (fileNode.temp) {
       //blank new file
+      this.editorControl.openFileHandler(fileNode);
       this.setMonacoModel(fileNode, <{ contents: string, etag: string, language: string }>{ contents: fileNode.changed ? fileNode.model.contents : '', etag: '', language: '' }, true).subscribe(() => {
         this.editorControl.fileOpened.next({ buffer: fileNode, file: fileNode.name });
         if (line) {
@@ -335,6 +336,8 @@ export class MonacoService implements OnDestroy {
     } else {
       this.getFileRequestObservable(fileNode, reload, line).subscribe({
         next: (response: any) => {
+          // Preflight passed (and user confirmed if oversized) — now add the tab
+          this.editorControl.openFileHandler(fileNode);
           //network load or switched to currently open file
           const resJson = response;
           this.setMonacoModel(fileNode, <{ contents: string, etag: string, language: string }>resJson, true).subscribe({
@@ -357,7 +360,6 @@ export class MonacoService implements OnDestroy {
           });
         },
         error: (err) => {
-          this.editorControl.closeFileHandler(fileNode);
           if (err._userCancelled) {
             return; // User cancelled from the large file warning dialog
           }

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -27,7 +27,7 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { finalize, map, switchMap, tap } from 'rxjs/operators';
 import { of, Subject, Observable, throwError } from 'rxjs';
 import { LoadingStatus } from '../loading-status';
-import { HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpEventType, HttpEvent } from '@angular/common/http';
 import * as _ from 'lodash';
 
 const DIFF_VIEW_ELEM = "monaco-diff-viewer";
@@ -44,6 +44,7 @@ export class MonacoService implements OnDestroy {
   constructor(
     @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger,
     private http: HttpService,
+    private httpClient: HttpClient,
     private dataAdapter: DataAdapterService,
     private editorControl: EditorControlService,
     private dialog: MatDialog,
@@ -119,15 +120,20 @@ export class MonacoService implements OnDestroy {
     // Pre-check to avoid downloading oversized files/datasets
     let preflight$;
     if (fileNode.model.isDataset) {
-      // For datasets, estimate size using 3390 DASD geometry from space allocation metadata.
-      // The metadata provides space type (CYL/TRK/MB/KB/BYTE) and primary allocation amount,
-      // which lets us compute an estimated byte size before downloading the content.
-      const attrs = fileNode.model.datasetAttrs;
-      const estimatedSize = this.limitsService.estimateDatasetSize(attrs);
-      if (estimatedSize > 0 && estimatedSize > maxSize) {
-        this.log.warn(`Dataset ${fileNode.name} estimated size ${estimatedSize} bytes (space=${attrs.space}, prime=${attrs.prime}) exceeds limit ${maxSize}`);
-        preflight$ = throwError({ _fileTooLarge: true, status: 413,
-          message: `Dataset "${fileNode.name}" is too large (estimated ${(estimatedSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
+      // For sequential datasets (not PDS members), estimate size via 3390 DASD geometry.
+      // PDS members share the parent PDS allocation so DASD math would over-estimate;
+      // they are protected by the streaming download abort below instead.
+      const isPdsMember = fileNode.model.path && fileNode.model.path.indexOf('(') !== -1;
+      if (!isPdsMember) {
+        const attrs = fileNode.model.datasetAttrs;
+        const estimatedSize = this.limitsService.estimateDatasetSize(attrs);
+        if (estimatedSize > 0 && estimatedSize > maxSize) {
+          this.log.warn(`Dataset ${fileNode.name} estimated size ${estimatedSize} bytes (space=${attrs.space}, prime=${attrs.prime}) exceeds limit ${maxSize}`);
+          preflight$ = throwError({ _fileTooLarge: true, status: 413,
+            message: `Dataset "${fileNode.name}" is too large (estimated ${(estimatedSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
+        } else {
+          preflight$ = of(true);
+        }
       } else {
         preflight$ = of(true);
       }
@@ -150,21 +156,66 @@ export class MonacoService implements OnDestroy {
 
     return preflight$.pipe(
       tap(() => this.loadingStatusChanged.next('loading')),
-      switchMap(() => this.http.get(requestUrl, options)),
+      switchMap(() => this.getSizeLimitedResponse(requestUrl, options, maxSize)),
       map((res: any) => {
         if (fileNode.model.isDataset) {
-          const result = this.dataAdapter.convertDatasetContent(res);
-          if (result.contents && result.contents.length > maxSize) {
-            throw { _fileTooLarge: true, status: 413,
-              message: `Dataset "${fileNode.name}" content is too large (${(result.contents.length / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` };
-          }
-          return result;
+          return this.dataAdapter.convertDatasetContent(res);
         } else {
           return this.dataAdapter.convertFileContent(res);
         }
       }),
       finalize(() => this.loadingStatusChanged.next('complete'))
     );
+  }
+
+  /**
+   * Fetches a URL while monitoring download progress. If the downloaded bytes
+   * exceed maxSize, the request is cancelled immediately. This breaks the server's
+   * socket so it stops streaming and doing CPU-intensive JSON conversion work.
+   * Prevents the jsonConvertAndWriteBuffer() errors from burning server CPU.
+   */
+  private getSizeLimitedResponse(url: string, options: any, maxSize: number): Observable<any> {
+    const maxSizeLabel = this.limitsService.getFormattedMaxSize();
+
+    return new Observable((observer) => {
+      const sub = this.httpClient.get(url, {
+        headers: options.headers,
+        responseType: 'text',
+        reportProgress: true,
+        observe: 'events'
+      }).subscribe({
+        next: (event: HttpEvent<string>) => {
+          if (event.type === HttpEventType.ResponseHeader) {
+            // Check Content-Length header if the server provides it
+            const contentLength = parseInt(event.headers.get('Content-Length') || '0', 10);
+            if (contentLength > maxSize) {
+              this.log.warn(`Response Content-Length ${contentLength} exceeds limit ${maxSize}, aborting download`);
+              sub.unsubscribe(); // Cancels the XMLHttpRequest, breaking the server's socket
+              observer.error({ _fileTooLarge: true, status: 413,
+                message: `Content is too large (${(contentLength / 1000000).toFixed(1)}MB from Content-Length). Maximum allowed size is ${maxSizeLabel}.` });
+            }
+          } else if (event.type === HttpEventType.DownloadProgress) {
+            // Monitor streaming progress and abort if accumulated bytes exceed limit
+            if (event.loaded > maxSize) {
+              this.log.warn(`Download progress ${event.loaded} bytes exceeds limit ${maxSize}, aborting`);
+              sub.unsubscribe();
+              observer.error({ _fileTooLarge: true, status: 413,
+                message: `Download exceeded maximum allowed size of ${maxSizeLabel}. Transfer was cancelled to protect server resources.` });
+            }
+          } else if (event.type === HttpEventType.Response) {
+            // Full response received within limits
+            observer.next(event.body);
+            observer.complete();
+          }
+        },
+        error: (err) => {
+          observer.error(err);
+        }
+      });
+
+      // If the outer observable is unsubscribed, cancel the HTTP request too
+      return () => sub.unsubscribe();
+    });
   }
 
   refreshFile(fileNode: ProjectContext, reload: boolean, line?: number) {

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -142,7 +142,7 @@ export class MonacoService implements OnDestroy {
         if (estimatedSize > 0 && estimatedSize > maxSize) {
           this.log.warn(`Dataset ${fileNode.name} estimated size ${estimatedSize} bytes (org=${org}, space=${attrs.space}, prime=${attrs.prime}) exceeds limit ${maxSize}`);
           preflight$ = this.confirmLargeFileOpen(fileNode.name,
-            `has an estimated size of ${(estimatedSize / 1000000).toFixed(1)}MB`, maxSizeLabel);
+            `has an estimated size of ${(estimatedSize / 1048576).toFixed(1)}MB`, maxSizeLabel);
         } else {
           preflight$ = of(false);
         }
@@ -156,7 +156,7 @@ export class MonacoService implements OnDestroy {
         if (knownSize > maxSize) {
           this.log.warn(`File ${fileNode.name} size ${knownSize} (from directory listing) exceeds limit ${maxSize}`);
           preflight$ = this.confirmLargeFileOpen(fileNode.name,
-            `is ${(knownSize / 1000000).toFixed(1)}MB`, maxSizeLabel);
+            `is ${(knownSize / 1048576).toFixed(1)}MB`, maxSizeLabel);
         } else {
           preflight$ = of(false);
         }
@@ -169,7 +169,7 @@ export class MonacoService implements OnDestroy {
             if (fileSize > maxSize) {
               this.log.warn(`File ${fileNode.name} size ${fileSize} exceeds limit ${maxSize}`);
               return this.confirmLargeFileOpen(fileNode.name,
-                `is ${(fileSize / 1000000).toFixed(1)}MB`, maxSizeLabel);
+                `is ${(fileSize / 1048576).toFixed(1)}MB`, maxSizeLabel);
             }
             return of(false);
           })
@@ -224,7 +224,7 @@ export class MonacoService implements OnDestroy {
               this.log.warn(`Response Content-Length ${contentLength} exceeds limit ${maxSize}, aborting download`);
               sub.unsubscribe(); // Cancels the XMLHttpRequest, breaking the server's socket
               observer.error({ _fileTooLarge: true,
-                message: `Content is too large (${(contentLength / 1000000).toFixed(1)}MB from Content-Length). Maximum allowed size is ${maxSizeLabel}.` });
+                message: `Content is too large (${(contentLength / 1048576).toFixed(1)}MB from Content-Length). Maximum allowed size is ${maxSizeLabel}.` });
             }
           } else if (event.type === HttpEventType.DownloadProgress) {
             // Monitor streaming progress and abort if accumulated bytes exceed limit
@@ -336,7 +336,7 @@ export class MonacoService implements OnDestroy {
     } else {
       this.getFileRequestObservable(fileNode, reload, line).subscribe({
         next: (response: any) => {
-          // Preflight passed (and user confirmed if oversized) — now add the tab
+          // Preflight passed (and user confirmed if oversized) -- now add the tab
           this.editorControl.openFileHandler(fileNode);
           //network load or switched to currently open file
           const resJson = response;

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -116,24 +116,37 @@ export class MonacoService implements OnDestroy {
     const maxSize = this.limitsService.limits.maxFileSize;
     const maxSizeLabel = this.limitsService.getFormattedMaxSize();
 
-    // For USS files, do a metadata pre-check to avoid downloading oversized files
-    const preflight$ = fileNode.model.isDataset
-      ? of(true)
-      : (() => {
-          const metadataUrl = ZoweZLUX.uriBroker.unixFileUri('metadata',
-            filePath + '/' + fileNode.model.fileName);
-          return this.http.get(metadataUrl).pipe(
-            switchMap((metadata: any) => {
-              const fileSize = metadata && metadata.size != null ? metadata.size : 0;
-              if (fileSize > maxSize) {
-                this.log.warn(`File ${fileNode.name} size ${fileSize} exceeds limit ${maxSize}`);
-                return throwError({ _fileTooLarge: true, status: 413,
-                  message: `File "${fileNode.name}" is too large (${(fileSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
-              }
-              return of(true);
-            })
-          );
-        })();
+    // Pre-check to avoid downloading oversized files/datasets
+    let preflight$;
+    if (fileNode.model.isDataset) {
+      // For datasets, estimate size using 3390 DASD geometry from space allocation metadata.
+      // The metadata provides space type (CYL/TRK/MB/KB/BYTE) and primary allocation amount,
+      // which lets us compute an estimated byte size before downloading the content.
+      const attrs = fileNode.model.datasetAttrs;
+      const estimatedSize = this.limitsService.estimateDatasetSize(attrs);
+      if (estimatedSize > 0 && estimatedSize > maxSize) {
+        this.log.warn(`Dataset ${fileNode.name} estimated size ${estimatedSize} bytes (space=${attrs.space}, prime=${attrs.prime}) exceeds limit ${maxSize}`);
+        preflight$ = throwError({ _fileTooLarge: true, status: 413,
+          message: `Dataset "${fileNode.name}" is too large (estimated ${(estimatedSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
+      } else {
+        preflight$ = of(true);
+      }
+    } else {
+      // For USS files, do a metadata pre-check to avoid downloading oversized files
+      const metadataUrl = ZoweZLUX.uriBroker.unixFileUri('metadata',
+        filePath + '/' + fileNode.model.fileName);
+      preflight$ = this.http.get(metadataUrl).pipe(
+        switchMap((metadata: any) => {
+          const fileSize = metadata && metadata.size != null ? metadata.size : 0;
+          if (fileSize > maxSize) {
+            this.log.warn(`File ${fileNode.name} size ${fileSize} exceeds limit ${maxSize}`);
+            return throwError({ _fileTooLarge: true, status: 413,
+              message: `File "${fileNode.name}" is too large (${(fileSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
+          }
+          return of(true);
+        })
+      );
+    }
 
     return preflight$.pipe(
       tap(() => this.loadingStatusChanged.next('loading')),

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -128,21 +128,22 @@ export class MonacoService implements OnDestroy {
         // PDS members share the parent PDS allocation so DASD math would over-estimate;
         // they are protected by the streaming download abort below instead.
         preflight$ = of(true);
-      } else if (org === 'PS' || org === 'PS-E' || org === 'DA') {
-        // Sequential or Direct Access datasets: estimate size via 3390 DASD geometry.
+      } else if (org === 'vsam') {
+        // VSAM datasets have different allocation semantics (CI/CA sizes, key ranges);
+        // space/prime don't map to data size the same way. Rely on streaming abort.
+        this.log.debug(`Dataset ${fileNode.name} is VSAM, skipping DASD size estimation`);
+        preflight$ = of(true);
+      } else {
+        // Sequential, partitioned (whole PDS), HFS, DA, and other non-VSAM datasets:
+        // estimate size via 3390 DASD geometry using space/prime allocation.
         const estimatedSize = this.limitsService.estimateDatasetSize(attrs);
         if (estimatedSize > 0 && estimatedSize > maxSize) {
-          this.log.warn(`Dataset ${fileNode.name} estimated size ${estimatedSize} bytes (space=${attrs.space}, prime=${attrs.prime}) exceeds limit ${maxSize}`);
+          this.log.warn(`Dataset ${fileNode.name} estimated size ${estimatedSize} bytes (org=${org}, space=${attrs.space}, prime=${attrs.prime}) exceeds limit ${maxSize}`);
           preflight$ = throwError({ _fileTooLarge: true,
             message: `Dataset "${fileNode.name}" is too large (estimated ${(estimatedSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
         } else {
           preflight$ = of(true);
         }
-      } else {
-        // Other organizations (PO without member, VSAM, etc.): skip DASD preflight.
-        // The streaming download abort (getSizeLimitedResponse) still protects against oversized responses.
-        this.log.debug(`Dataset ${fileNode.name} has organization="${org}", skipping DASD size estimation`);
-        preflight$ = of(true);
       }
     } else {
       // For USS files, check size from the directory listing first (already on the model).
@@ -178,10 +179,14 @@ export class MonacoService implements OnDestroy {
       tap(() => this.loadingStatusChanged.next('loading')),
       switchMap(() => this.getSizeLimitedResponse(requestUrl, options, maxSize)),
       map((res: any) => {
-        if (fileNode.model.isDataset) {
-          return this.dataAdapter.convertDatasetContent(res);
-        } else {
-          return this.dataAdapter.convertFileContent(res);
+        try {
+          if (fileNode.model.isDataset) {
+            return this.dataAdapter.convertDatasetContent(res);
+          } else {
+            return this.dataAdapter.convertFileContent(res);
+          }
+        } catch (e) {
+          throw { status: 0, _body: `Failed to parse server response for ${fileNode.name}: ${e.message || e}` };
         }
       }),
       finalize(() => this.loadingStatusChanged.next('complete'))
@@ -229,6 +234,17 @@ export class MonacoService implements OnDestroy {
           }
         },
         error: (err) => {
+          // Normalize HttpErrorResponse so downstream error handlers can use
+          // the same properties (status, _body) they expect from HttpService.
+          if (err && err.status != null && err._body === undefined) {
+            let body = '';
+            if (typeof err.error === 'string' && err.error) {
+              body = err.error;
+            } else if (err.error && typeof err.error === 'object') {
+              body = err.error.message || err.error.error || '';
+            }
+            err._body = body || err.statusText || `Server returned status ${err.status}`;
+          }
           observer.error(err);
         }
       });

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -120,38 +120,58 @@ export class MonacoService implements OnDestroy {
     // Pre-check to avoid downloading oversized files/datasets
     let preflight$;
     if (fileNode.model.isDataset) {
-      // For sequential datasets (not PDS members), estimate size via 3390 DASD geometry.
-      // PDS members share the parent PDS allocation so DASD math would over-estimate;
-      // they are protected by the streaming download abort below instead.
       const isPdsMember = fileNode.model.path && fileNode.model.path.indexOf('(') !== -1;
-      if (!isPdsMember) {
-        const attrs = fileNode.model.datasetAttrs;
+      const attrs = fileNode.model.datasetAttrs;
+      const org = attrs && attrs.dsorg ? attrs.dsorg.organization : '';
+
+      if (isPdsMember) {
+        // PDS members share the parent PDS allocation so DASD math would over-estimate;
+        // they are protected by the streaming download abort below instead.
+        preflight$ = of(true);
+      } else if (org === 'PS' || org === 'PS-E' || org === 'DA') {
+        // Sequential or Direct Access datasets: estimate size via 3390 DASD geometry.
         const estimatedSize = this.limitsService.estimateDatasetSize(attrs);
         if (estimatedSize > 0 && estimatedSize > maxSize) {
           this.log.warn(`Dataset ${fileNode.name} estimated size ${estimatedSize} bytes (space=${attrs.space}, prime=${attrs.prime}) exceeds limit ${maxSize}`);
-          preflight$ = throwError({ _fileTooLarge: true, status: 413,
+          preflight$ = throwError({ _fileTooLarge: true,
             message: `Dataset "${fileNode.name}" is too large (estimated ${(estimatedSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
         } else {
           preflight$ = of(true);
         }
       } else {
+        // Other organizations (PO without member, VSAM, etc.): skip DASD preflight.
+        // The streaming download abort (getSizeLimitedResponse) still protects against oversized responses.
+        this.log.debug(`Dataset ${fileNode.name} has organization="${org}", skipping DASD size estimation`);
         preflight$ = of(true);
       }
     } else {
-      // For USS files, do a metadata pre-check to avoid downloading oversized files
-      const metadataUrl = ZoweZLUX.uriBroker.unixFileUri('metadata',
-        filePath + '/' + fileNode.model.fileName);
-      preflight$ = this.http.get(metadataUrl).pipe(
-        switchMap((metadata: any) => {
-          const fileSize = metadata && metadata.size != null ? metadata.size : 0;
-          if (fileSize > maxSize) {
-            this.log.warn(`File ${fileNode.name} size ${fileSize} exceeds limit ${maxSize}`);
-            return throwError({ _fileTooLarge: true, status: 413,
-              message: `File "${fileNode.name}" is too large (${(fileSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
-          }
-          return of(true);
-        })
-      );
+      // For USS files, check size from the directory listing first (already on the model).
+      // Fall back to a metadata API call only if size is not available (e.g. file opened
+      // outside of a directory listing, or listing did not include size).
+      const knownSize = fileNode.model.size;
+      if (knownSize != null && knownSize > 0) {
+        if (knownSize > maxSize) {
+          this.log.warn(`File ${fileNode.name} size ${knownSize} (from directory listing) exceeds limit ${maxSize}`);
+          preflight$ = throwError({ _fileTooLarge: true,
+            message: `File "${fileNode.name}" is too large (${(knownSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
+        } else {
+          preflight$ = of(true);
+        }
+      } else {
+        const metadataUrl = ZoweZLUX.uriBroker.unixFileUri('metadata',
+          filePath + '/' + fileNode.model.fileName);
+        preflight$ = this.http.get(metadataUrl).pipe(
+          switchMap((metadata: any) => {
+            const fileSize = metadata && metadata.size != null ? metadata.size : 0;
+            if (fileSize > maxSize) {
+              this.log.warn(`File ${fileNode.name} size ${fileSize} exceeds limit ${maxSize}`);
+              return throwError({ _fileTooLarge: true,
+                message: `File "${fileNode.name}" is too large (${(fileSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
+            }
+            return of(true);
+          })
+        );
+      }
     }
 
     return preflight$.pipe(
@@ -191,7 +211,7 @@ export class MonacoService implements OnDestroy {
             if (contentLength > maxSize) {
               this.log.warn(`Response Content-Length ${contentLength} exceeds limit ${maxSize}, aborting download`);
               sub.unsubscribe(); // Cancels the XMLHttpRequest, breaking the server's socket
-              observer.error({ _fileTooLarge: true, status: 413,
+              observer.error({ _fileTooLarge: true,
                 message: `Content is too large (${(contentLength / 1000000).toFixed(1)}MB from Content-Length). Maximum allowed size is ${maxSizeLabel}.` });
             }
           } else if (event.type === HttpEventType.DownloadProgress) {
@@ -199,7 +219,7 @@ export class MonacoService implements OnDestroy {
             if (event.loaded > maxSize) {
               this.log.warn(`Download progress ${event.loaded} bytes exceeds limit ${maxSize}, aborting`);
               sub.unsubscribe();
-              observer.error({ _fileTooLarge: true, status: 413,
+              observer.error({ _fileTooLarge: true,
                 message: `Download exceeded maximum allowed size of ${maxSizeLabel}. Transfer was cancelled to protect server resources.` });
             }
           } else if (event.type === HttpEventType.Response) {

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -24,7 +24,7 @@ import { SnackBarService } from '../../../shared/snack-bar.service';
 import { MessageDuration } from '../../../shared/message-duration';
 import { LimitsService } from '../../../shared/limits.service';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
-import { finalize, map, switchMap, tap } from 'rxjs/operators';
+import { finalize, map, switchMap, tap, take } from 'rxjs/operators';
 import { of, Subject, Observable, throwError } from 'rxjs';
 import { LoadingStatus } from '../loading-status';
 import { HttpClient, HttpHeaders, HttpEventType, HttpEvent } from '@angular/common/http';
@@ -117,8 +117,10 @@ export class MonacoService implements OnDestroy {
     const maxSize = this.limitsService.limits.maxFileSize;
     const maxSizeLabel = this.limitsService.getFormattedMaxSize();
 
-    // Pre-check to avoid downloading oversized files/datasets
-    let preflight$;
+    // Pre-check to avoid downloading oversized files/datasets.
+    // If the file exceeds the limit, prompt the user with a warning dialog.
+    // If they choose to override, download without a size cap.
+    let preflight$: Observable<boolean>;
     if (fileNode.model.isDataset) {
       const isPdsMember = fileNode.model.path && fileNode.model.path.indexOf('(') !== -1;
       const attrs = fileNode.model.datasetAttrs;
@@ -127,22 +129,22 @@ export class MonacoService implements OnDestroy {
       if (isPdsMember) {
         // PDS members share the parent PDS allocation so DASD math would over-estimate;
         // they are protected by the streaming download abort below instead.
-        preflight$ = of(true);
+        preflight$ = of(false);
       } else if (org === 'vsam') {
         // VSAM datasets have different allocation semantics (CI/CA sizes, key ranges);
         // space/prime don't map to data size the same way. Rely on streaming abort.
         this.log.debug(`Dataset ${fileNode.name} is VSAM, skipping DASD size estimation`);
-        preflight$ = of(true);
+        preflight$ = of(false);
       } else {
         // Sequential, partitioned (whole PDS), HFS, DA, and other non-VSAM datasets:
         // estimate size via 3390 DASD geometry using space/prime allocation.
         const estimatedSize = this.limitsService.estimateDatasetSize(attrs);
         if (estimatedSize > 0 && estimatedSize > maxSize) {
           this.log.warn(`Dataset ${fileNode.name} estimated size ${estimatedSize} bytes (org=${org}, space=${attrs.space}, prime=${attrs.prime}) exceeds limit ${maxSize}`);
-          preflight$ = throwError({ _fileTooLarge: true,
-            message: `Dataset "${fileNode.name}" is too large (estimated ${(estimatedSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
+          preflight$ = this.confirmLargeFileOpen(fileNode.name,
+            `has an estimated size of ${(estimatedSize / 1000000).toFixed(1)}MB`, maxSizeLabel);
         } else {
-          preflight$ = of(true);
+          preflight$ = of(false);
         }
       }
     } else {
@@ -153,10 +155,10 @@ export class MonacoService implements OnDestroy {
       if (knownSize != null && knownSize > 0) {
         if (knownSize > maxSize) {
           this.log.warn(`File ${fileNode.name} size ${knownSize} (from directory listing) exceeds limit ${maxSize}`);
-          preflight$ = throwError({ _fileTooLarge: true,
-            message: `File "${fileNode.name}" is too large (${(knownSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
+          preflight$ = this.confirmLargeFileOpen(fileNode.name,
+            `is ${(knownSize / 1000000).toFixed(1)}MB`, maxSizeLabel);
         } else {
-          preflight$ = of(true);
+          preflight$ = of(false);
         }
       } else {
         const metadataUrl = ZoweZLUX.uriBroker.unixFileUri('metadata',
@@ -166,18 +168,23 @@ export class MonacoService implements OnDestroy {
             const fileSize = metadata && metadata.size != null ? metadata.size : 0;
             if (fileSize > maxSize) {
               this.log.warn(`File ${fileNode.name} size ${fileSize} exceeds limit ${maxSize}`);
-              return throwError({ _fileTooLarge: true,
-                message: `File "${fileNode.name}" is too large (${(fileSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
+              return this.confirmLargeFileOpen(fileNode.name,
+                `is ${(fileSize / 1000000).toFixed(1)}MB`, maxSizeLabel);
             }
-            return of(true);
+            return of(false);
           })
         );
       }
     }
 
+    // preflight$ emits true if the user overrode the size limit, false if within limits.
+    // If the user cancelled, the observable errors with _fileTooLarge + _userCancelled.
     return preflight$.pipe(
       tap(() => this.loadingStatusChanged.next('loading')),
-      switchMap(() => this.getSizeLimitedResponse(requestUrl, options, maxSize)),
+      switchMap((userOverride: boolean) => {
+        const effectiveMaxSize = userOverride ? Number.MAX_SAFE_INTEGER : maxSize;
+        return this.getSizeLimitedResponse(requestUrl, options, effectiveMaxSize);
+      }),
       map((res: any) => {
         try {
           if (fileNode.model.isDataset) {
@@ -279,6 +286,9 @@ export class MonacoService implements OnDestroy {
         });
       },
       error: (err) => {
+        if (err._userCancelled) {
+          return; // User cancelled from the large file warning dialog
+        }
         this.log.warn(`${fileNode.name} could not be refreshed, status: `, err.status);
         if (err._fileTooLarge) {
           this.snackBar.open(err.message,
@@ -348,6 +358,9 @@ export class MonacoService implements OnDestroy {
         },
         error: (err) => {
           this.editorControl.closeFileHandler(fileNode);
+          if (err._userCancelled) {
+            return; // User cancelled from the large file warning dialog
+          }
           this.log.warn(`${fileNode.name} could not be opened, status: `, err.status);
           if (err._fileTooLarge) {
             this.snackBar.open(err.message,
@@ -539,6 +552,35 @@ export class MonacoService implements OnDestroy {
       }
     });
     return dialogRef.afterClosed();
+  }
+
+  /**
+   * Shows a warning dialog for oversized files/datasets.
+   * Returns an Observable that emits true if the user overrides, or throws _fileTooLarge if cancelled.
+   */
+  private confirmLargeFileOpen(fileName: string, sizeDescription: string, maxSizeLabel: string): Observable<boolean> {
+    const dialogRef = this.dialog.open(ConfirmAction, {
+      maxWidth: '480px',
+      data: {
+        title: 'Large File Warning',
+        warningMessage: `"${fileName}" ${sizeDescription} which exceeds the ${maxSizeLabel} limit. `
+          + `Opening very large files in the editor may cause high memory usage or CPU load. `
+          + `We recommend downloading the file and viewing it on your desktop instead.`,
+        confirmLabel: 'Open Anyway',
+        dismissLabel: 'Cancel'
+      }
+    });
+    return dialogRef.afterClosed().pipe(
+      take(1),
+      switchMap((confirmed: boolean) => {
+        if (confirmed) {
+          this.log.info(`User chose to override size limit for ${fileName}`);
+          return of(true);
+        }
+        return throwError({ _fileTooLarge: true, _userCancelled: true,
+          message: `Opening "${fileName}" was cancelled.` });
+      })
+    );
   }
 
   preSaveCheck(fileContext?: ProjectContext): boolean {

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -22,9 +22,10 @@ import { ConfirmAction } from '../../../shared/dialog/confirm-action/confirm-act
 import { TagComponent } from '../../../shared/dialog/tag/tag.component';
 import { SnackBarService } from '../../../shared/snack-bar.service';
 import { MessageDuration } from '../../../shared/message-duration';
+import { LimitsService } from '../../../shared/limits.service';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { finalize, map, switchMap, tap } from 'rxjs/operators';
-import { of, Subject, Observable } from 'rxjs';
+import { of, Subject, Observable, throwError } from 'rxjs';
 import { LoadingStatus } from '../loading-status';
 import { HttpHeaders } from '@angular/common/http';
 import * as _ from 'lodash';
@@ -46,7 +47,8 @@ export class MonacoService implements OnDestroy {
     private dataAdapter: DataAdapterService,
     private editorControl: EditorControlService,
     private dialog: MatDialog,
-    private snackBar: SnackBarService
+    private snackBar: SnackBarService,
+    private limitsService: LimitsService
   ) {
     this.editorControl.closeFile.subscribe((fileContext: ProjectContext) => {
       this.closeFile(fileContext);
@@ -110,12 +112,40 @@ export class MonacoService implements OnDestroy {
       headers: headers,
       responseType: 'text',
     }
-    return of({}).pipe(
+
+    const maxSize = this.limitsService.limits.maxFileSize;
+    const maxSizeLabel = this.limitsService.getFormattedMaxSize();
+
+    // For USS files, do a metadata pre-check to avoid downloading oversized files
+    const preflight$ = fileNode.model.isDataset
+      ? of(true)
+      : (() => {
+          const metadataUrl = ZoweZLUX.uriBroker.unixFileUri('metadata',
+            filePath + '/' + fileNode.model.fileName);
+          return this.http.get(metadataUrl).pipe(
+            switchMap((metadata: any) => {
+              const fileSize = metadata && metadata.size != null ? metadata.size : 0;
+              if (fileSize > maxSize) {
+                this.log.warn(`File ${fileNode.name} size ${fileSize} exceeds limit ${maxSize}`);
+                return throwError({ _fileTooLarge: true, status: 413,
+                  message: `File "${fileNode.name}" is too large (${(fileSize / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` });
+              }
+              return of(true);
+            })
+          );
+        })();
+
+    return preflight$.pipe(
       tap(() => this.loadingStatusChanged.next('loading')),
       switchMap(() => this.http.get(requestUrl, options)),
       map((res: any) => {
         if (fileNode.model.isDataset) {
-          return this.dataAdapter.convertDatasetContent(res);
+          const result = this.dataAdapter.convertDatasetContent(res);
+          if (result.contents && result.contents.length > maxSize) {
+            throw { _fileTooLarge: true, status: 413,
+              message: `Dataset "${fileNode.name}" content is too large (${(result.contents.length / 1000000).toFixed(1)}MB). Maximum allowed size is ${maxSizeLabel}.` };
+          }
+          return result;
         } else {
           return this.dataAdapter.convertFileContent(res);
         }
@@ -150,7 +180,10 @@ export class MonacoService implements OnDestroy {
       },
       error: (err) => {
         this.log.warn(`${fileNode.name} could not be refreshed, status: `, err.status);
-        if (err.status === 403) {
+        if (err._fileTooLarge) {
+          this.snackBar.open(err.message,
+            'Close', { duration: MessageDuration.Long, panelClass: 'center' });
+        } else if (err.status === 403) {
           this.snackBar.open(`${fileNode.name} could not be refreshed due to permissions.`,
             'Close', { duration: MessageDuration.Medium, panelClass: 'center' });
         } else if (err.status === 404) {
@@ -216,7 +249,10 @@ export class MonacoService implements OnDestroy {
         error: (err) => {
           this.editorControl.closeFileHandler(fileNode);
           this.log.warn(`${fileNode.name} could not be opened, status: `, err.status);
-          if (err.status === 403) {
+          if (err._fileTooLarge) {
+            this.snackBar.open(err.message,
+              'Close', { duration: MessageDuration.Long, panelClass: 'center' });
+          } else if (err.status === 403) {
             this.snackBar.open(`${fileNode.name} could not be opened due to permissions.`,
               'Close', { duration: MessageDuration.Medium, panelClass: 'center' });
           } else if (err.status === 404) {

--- a/webClient/src/app/shared/dialog/confirm-action/confirm-action-component.html
+++ b/webClient/src/app/shared/dialog/confirm-action/confirm-action-component.html
@@ -8,20 +8,20 @@
   Copyright Contributors to the Zowe Project.
 -->
 <zlux-tab-trap></zlux-tab-trap>
-<div class="d-flex flex-align-items-start">
+<div class="d-flex flex-align-items-start" data-testid="confirm-action-dialog">
   <div>
-    <h2 mat-dialog-title>{{data.title}}</h2>
+    <h2 mat-dialog-title data-testid="confirm-action-title">{{data.title}}</h2>
   </div>
-  <button mat-dialog-close class="close-dialog-btn" (click)="onCancel()">
+  <button mat-dialog-close class="close-dialog-btn" data-testid="confirm-action-close" (click)="onCancel()">
     <i class="fa fa-close"></i>
   </button>
 </div>
 <mat-dialog-content>
-  <p><b>Warning: </b>{{data.warningMessage}}</p>
+  <p data-testid="confirm-action-warning"><b>Warning: </b>{{data.warningMessage}}</p>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-flat-button class="right" color="primary" (click)="onConfirm()">{{data.confirmLabel || 'Yes'}}</button>
-  <button mat-button class="right" (click)="onDismiss()">{{data.dismissLabel || 'No'}}</button>
+  <button mat-flat-button class="right" color="primary" data-testid="confirm-action-confirm" (click)="onConfirm()">{{data.confirmLabel || 'Yes'}}</button>
+  <button mat-button class="right" data-testid="confirm-action-dismiss" (click)="onDismiss()">{{data.dismissLabel || 'No'}}</button>
 </mat-dialog-actions>
 
 <!-- 

--- a/webClient/src/app/shared/dialog/confirm-action/confirm-action-component.html
+++ b/webClient/src/app/shared/dialog/confirm-action/confirm-action-component.html
@@ -20,8 +20,8 @@
   <p><b>Warning: </b>{{data.warningMessage}}</p>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-flat-button class="right" color="primary" (click)="onConfirm()">Yes</button>
-  <button mat-button class="right" (click)="onDismiss()">No</button>
+  <button mat-flat-button class="right" color="primary" (click)="onConfirm()">{{data.confirmLabel || 'Yes'}}</button>
+  <button mat-button class="right" (click)="onDismiss()">{{data.dismissLabel || 'No'}}</button>
 </mat-dialog-actions>
 
 <!-- 

--- a/webClient/src/app/shared/dialog/confirm-action/confirm-action-component.ts
+++ b/webClient/src/app/shared/dialog/confirm-action/confirm-action-component.ts
@@ -15,6 +15,8 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 export interface DialogData {
   title: string;
   warningMessage: string;
+  confirmLabel?: string;
+  dismissLabel?: string;
 }
 
 @Component({

--- a/webClient/src/app/shared/http/http.data.adapter.service.ts
+++ b/webClient/src/app/shared/http/http.data.adapter.service.ts
@@ -67,7 +67,8 @@ export class DataAdapterService {
           volser: entry.volser,
           space: entry.space,
           prime: entry.prime,
-          secnd: entry.secnd
+          secnd: entry.secnd,
+          totalBlockSize: entry.dsorg ? entry.dsorg.totalBlockSize : undefined
         }
       };
     });
@@ -92,7 +93,8 @@ export class DataAdapterService {
           volser: parent.volser,
           space: parent.space,
           prime: parent.prime,
-          secnd: parent.secnd
+          secnd: parent.secnd,
+          totalBlockSize: parent.dsorg ? parent.dsorg.totalBlockSize : undefined
         }
       };
     });

--- a/webClient/src/app/shared/http/http.data.adapter.service.ts
+++ b/webClient/src/app/shared/http/http.data.adapter.service.ts
@@ -42,7 +42,8 @@ export class DataAdapterService {
         path: eFilePath,
         fileName: eFileName,
         isDataset: false,
-        encoding: eEncoding
+        encoding: eEncoding,
+        size: entry.size
       };
     });
   }

--- a/webClient/src/app/shared/http/http.data.adapter.service.ts
+++ b/webClient/src/app/shared/http/http.data.adapter.service.ts
@@ -63,7 +63,10 @@ export class DataAdapterService {
           csiEntryType: entry.csiEntryType,
           dsorg: entry.dsorg,
           recfm: entry.recfm,
-          volser: entry.volser
+          volser: entry.volser,
+          space: entry.space,
+          prime: entry.prime,
+          secnd: entry.secnd
         }
       };
     });
@@ -85,7 +88,10 @@ export class DataAdapterService {
           csiEntryType: parent.csiEntryType,
           dsorg: parent.dsorg,
           recfm: parent.recfm,
-          volser: parent.volser
+          volser: parent.volser,
+          space: parent.space,
+          prime: parent.prime,
+          secnd: parent.secnd
         }
       };
     });

--- a/webClient/src/app/shared/limits.service.ts
+++ b/webClient/src/app/shared/limits.service.ts
@@ -114,6 +114,10 @@ export class LimitsService {
         return prime * 1024;
       case 'BYTE':
         return prime;
+      case 'BLK': {
+        const blockSize = attrs.totalBlockSize;
+        return blockSize > 0 ? prime * blockSize : -1;
+      }
       default:
         return -1;
     }

--- a/webClient/src/app/shared/limits.service.ts
+++ b/webClient/src/app/shared/limits.service.ts
@@ -19,7 +19,7 @@ export interface EditorLimits {
 }
 
 const DEFAULT_LIMITS: EditorLimits = {
-  maxFileSize: 50000000,
+  maxFileSize: 52428800,
   folderMaxCount: 200
 };
 
@@ -71,16 +71,12 @@ export class LimitsService {
     );
   }
 
-  isFileSizeAllowed(sizeInBytes: number): boolean {
-    return sizeInBytes <= this._limits.getValue().maxFileSize;
-  }
-
   getFormattedMaxSize(): string {
     const bytes = this._limits.getValue().maxFileSize;
-    if (bytes >= 1000000) {
-      return `${(bytes / 1000000).toFixed(0)}MB`;
+    if (bytes >= 1048576) {
+      return `${(bytes / 1048576).toFixed(0)}MB`;
     }
-    return `${(bytes / 1000).toFixed(0)}KB`;
+    return `${(bytes / 1024).toFixed(0)}KB`;
   }
 
   /**

--- a/webClient/src/app/shared/limits.service.ts
+++ b/webClient/src/app/shared/limits.service.ts
@@ -9,6 +9,7 @@
 */
 import { Injectable, Inject } from '@angular/core';
 import { HttpService } from './http/http.service';
+import { DatasetAttributes } from './model/editor-project';
 import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 import { BehaviorSubject } from 'rxjs';
 
@@ -80,6 +81,42 @@ export class LimitsService {
       return `${(bytes / 1000000).toFixed(0)}MB`;
     }
     return `${(bytes / 1000).toFixed(0)}KB`;
+  }
+
+  /**
+   * Estimates dataset size in bytes using 3390 CKD DASD geometry.
+   * 3390: 56,664 bytes/track, 15 tracks/cylinder, 849,960 bytes/cylinder.
+   * The metadata response provides `space` (unit type) and `prime` (primary allocation).
+   * Returns estimated bytes, or -1 if estimation is not possible.
+   */
+  estimateDatasetSize(attrs: DatasetAttributes): number {
+    // Constants from IBM 3390 DASD geometry
+    // https://www.ibm.com/docs/en/zos/2.1.0?topic=devices-direct-access-storage
+    const BYTES_PER_TRACK = 56664;
+    const TRACKS_PER_CYLINDER = 15;
+    const BYTES_PER_CYLINDER = BYTES_PER_TRACK * TRACKS_PER_CYLINDER; // 849,960
+
+    if (!attrs || attrs.prime == null || attrs.prime <= 0 || !attrs.space) {
+      return -1;
+    }
+
+    const prime = attrs.prime;
+    const space = attrs.space.toUpperCase();
+
+    switch (space) {
+      case 'CYL':
+        return prime * BYTES_PER_CYLINDER;
+      case 'TRK':
+        return prime * BYTES_PER_TRACK;
+      case 'MB':
+        return prime * 1048576;
+      case 'KB':
+        return prime * 1024;
+      case 'BYTE':
+        return prime;
+      default:
+        return -1;
+    }
   }
 }
 

--- a/webClient/src/app/shared/limits.service.ts
+++ b/webClient/src/app/shared/limits.service.ts
@@ -1,0 +1,94 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+import { Injectable, Inject } from '@angular/core';
+import { HttpService } from './http/http.service';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
+import { BehaviorSubject } from 'rxjs';
+
+export interface EditorLimits {
+  maxFileSize: number;
+  folderMaxCount: number;
+}
+
+const DEFAULT_LIMITS: EditorLimits = {
+  maxFileSize: 50000000,
+  folderMaxCount: 200
+};
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LimitsService {
+  private _limits: BehaviorSubject<EditorLimits> = new BehaviorSubject<EditorLimits>(DEFAULT_LIMITS);
+
+  constructor(
+    private http: HttpService,
+    @Inject(Angular2InjectionTokens.PLUGIN_DEFINITION) private pluginDefinition: ZLUX.ContainerPluginDefinition,
+    @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger
+  ) {
+    this.loadLimits();
+  }
+
+  get limits(): EditorLimits {
+    return this._limits.getValue();
+  }
+
+  get limits$(): BehaviorSubject<EditorLimits> {
+    return this._limits;
+  }
+
+  private loadLimits(): void {
+    const uri = ZoweZLUX.uriBroker.pluginConfigUri(
+      this.pluginDefinition.getBasePlugin(),
+      'limits',
+      'limits.json'
+    );
+    this.http.get(uri).subscribe(
+      (response: any) => {
+        if (response && response.contents) {
+          const contents = response.contents;
+          const merged: EditorLimits = {
+            maxFileSize: typeof contents.maxFileSize === 'number' ? contents.maxFileSize : DEFAULT_LIMITS.maxFileSize,
+            folderMaxCount: typeof contents.folderMaxCount === 'number' ? contents.folderMaxCount : DEFAULT_LIMITS.folderMaxCount
+          };
+          this._limits.next(merged);
+          this.log.info(`Loaded editor limits: maxFileSize=${merged.maxFileSize}, folderMaxCount=${merged.folderMaxCount}`);
+        } else {
+          this.log.info(`No limits config found, using defaults: maxFileSize=${DEFAULT_LIMITS.maxFileSize}, folderMaxCount=${DEFAULT_LIMITS.folderMaxCount}`);
+        }
+      },
+      (err: any) => {
+        this.log.warn(`Failed to load limits config, using defaults. Error:`, err);
+      }
+    );
+  }
+
+  isFileSizeAllowed(sizeInBytes: number): boolean {
+    return sizeInBytes <= this._limits.getValue().maxFileSize;
+  }
+
+  getFormattedMaxSize(): string {
+    const bytes = this._limits.getValue().maxFileSize;
+    if (bytes >= 1000000) {
+      return `${(bytes / 1000000).toFixed(0)}MB`;
+    }
+    return `${(bytes / 1000).toFixed(0)}KB`;
+  }
+}
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/

--- a/webClient/src/app/shared/model/editor-project.ts
+++ b/webClient/src/app/shared/model/editor-project.ts
@@ -32,7 +32,10 @@ export interface DatasetAttributes {
   dsorg?: DatasetOrganization,
   members?: Array<any>,
   recfm?: RecordFormat,
-  volser?: string
+  volser?: string,
+  space?: string,
+  prime?: number,
+  secnd?: number
 }
 
 export interface RecordFormat {

--- a/webClient/src/app/shared/model/editor-project.ts
+++ b/webClient/src/app/shared/model/editor-project.ts
@@ -36,7 +36,8 @@ export interface DatasetAttributes {
   volser?: string,
   space?: string,
   prime?: number,
-  secnd?: number
+  secnd?: number,
+  totalBlockSize?: number
 }
 
 export interface RecordFormat {

--- a/webClient/src/app/shared/model/editor-project.ts
+++ b/webClient/src/app/shared/model/editor-project.ts
@@ -22,6 +22,7 @@ export interface ProjectStructure {
     fileName?: string;
     isDataset: boolean;
     encoding?: number;
+    size?: number;
     datasetAttrs?: DatasetAttributes;
     etag?: string;
 }

--- a/webClient/src/app/shared/shared.module.ts
+++ b/webClient/src/app/shared/shared.module.ts
@@ -20,6 +20,7 @@ import { EditorControlService } from './editor-control/editor-control.service';
 import { SnackBarService } from './snack-bar.service';
 import { LanguageServerService } from './language-server/language-server.service';
 import { EditorKeybindingService } from './editor-keybinding.service';
+import { LimitsService } from './limits.service';
 
 @NgModule({
   imports: [
@@ -36,7 +37,8 @@ import { EditorKeybindingService } from './editor-keybinding.service';
     EditorControlService,
     SnackBarService,
     LanguageServerService,
-    EditorKeybindingService
+    EditorKeybindingService,
+    LimitsService
   ]
 })
 export class SharedModule { }


### PR DESCRIPTION
**PR description:**

Adds a configurable size limit (default 50MB) to prevent the editor from opening very large files or datasets that cause high memory usage on the client and CPU burn on the server.

 When a file exceeds the limit, a warning dialog appears *before* the tab is created, explaining the risk and recommending the user download the file to their desktop instead. Two buttons: "Open Anyway" (overrides the limit for this file) and "Cancel".
