### PR TITLE
Allow clicking items in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## `3.5.0`
 
 - Enhancement: The editor now recognizes and highlights clickable strings in file content. Ctrl+Click (Cmd+Click on macOS) on any of the following will trigger an action:
-  - **Unix file paths** (e.g. `/u/user/file.txt`): checks if the path is a file or directory; opens files in a new editor tab, and prompts to navigate the file explorer to directories.
-  - **Dataset names** (e.g. `DSNAME=A.B`, `//'A.B'`, `//'A.B(MEMBER)'`): opens the dataset or member in the editor.
-  - **URLs** (e.g. `https://example.com`): prompts the user before opening in a new browser tab.
-- Each of these behaviors can be individually enabled or disabled in the editor Settings menu (`Click Links File Path`, `Click Links Dataset`, `Click Links Url`), and all default to enabled.
+    - **Unix file paths** (e.g. `/u/user/file.txt`): checks if the path is a file or directory; opens files in a new editor tab, and prompts to navigate the file explorer to directories.
+    - **Dataset names** (e.g. `DSNAME=A.B`, `//'A.B'`, `//'A.B(MEMBER)'`): opens the dataset or member in the editor.
+    - **URLs** (e.g. `https://example.com`): prompts the user before opening in a new browser tab.
+    - Each of these behaviors can be individually enabled or disabled in the editor Settings menu (`Click Links File Path`, `Click Links Dataset`, `Click Links Url`), and all default to enabled.
 
 ## `3.4.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Zlux Editor Changelog
 
+## `3.5.0`
+
+- Enhancement: The editor now recognizes and highlights clickable strings in file content. Ctrl+Click (Cmd+Click on macOS) on any of the following will trigger an action:
+  - **Unix file paths** (e.g. `/u/user/file.txt`): checks if the path is a file or directory; opens files in a new editor tab, and prompts to navigate the file explorer to directories.
+  - **Dataset names** (e.g. `DSNAME=A.B`, `//'A.B'`, `//'A.B(MEMBER)'`): opens the dataset or member in the editor.
+  - **URLs** (e.g. `https://example.com`): prompts the user before opening in a new browser tab.
+- Each of these behaviors can be individually enabled or disabled in the editor Settings menu (`Click Links File Path`, `Click Links Dataset`, `Click Links Url`), and all default to enabled.
+
 ## `3.4.0`
 
 - Enhancement: Re-enabled JCL submit via submit menu and ability to view submitted job via JES Explorer desktop app.

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.scss
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.scss
@@ -27,6 +27,11 @@
       background-color: yellow;
       color: black;
     }
+    ::ng-deep .path-link {
+      text-decoration: underline;
+      color: #7fb3d3;
+      cursor: pointer;
+    }
     ::ng-deep .myLineDecoration {
       background: #e6e1ad; width: 50px !important; 
     }

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
@@ -29,9 +29,23 @@ import { SnackBarService } from '../../../shared/snack-bar.service';
 import { MessageDuration } from "../../../shared/message-duration";
 import { debounceTime } from 'rxjs/operators';
 import { UtilsService } from '../../../shared/utils.service';
+import { ProjectStructure } from '../../../shared/model/editor-project';
+import { MatDialog } from '@angular/material/dialog';
+import { ConfirmAction, DialogData } from '../../../shared/dialog/confirm-action/confirm-action-component';
 const ReconnectingWebSocket = require('reconnecting-websocket');
 
-@Component({
+// Matches absolute Unix-style paths, e.g. /u/user/file.txt or /etc/zowe/server.yaml
+const PATH_PATTERN = '\\/[a-zA-Z0-9._\\-@+#$~]+(?:\\/[a-zA-Z0-9._\\-@+#$~]+)*';
+// Matches MVS dataset notation: DSNAME=A.B or DSNAME=A.B(MEMBER)
+const DATASET_DSNAME_PATTERN =
+  'DSNAME=([A-Z@#$][A-Z0-9@#$-]{0,7}(?:\\.[A-Z@#$][A-Z0-9@#$-]{0,7})+(?:\\([A-Z@#$][A-Z0-9@#$-]{0,7}\\))?)';
+
+// Matches z/OS UNIX dataset path notation: //\'A.B\' or //\'A.B(MEMBER)\'
+const DATASET_SLASH_PATTERN =
+  "//'([A-Z@#$][A-Z0-9@#$-]{0,7}(?:\\.[A-Z@#$][A-Z0-9@#$-]{0,7})+(?:\\([A-Z@#$][A-Z0-9@#$-]{0,7}\\))?)'";
+
+// Matches http:// or https:// URLs
+const URL_PATTERN = 'https?://[^\\s<>{}\\[\\]]+';@Component({
   selector: 'app-monaco',
   templateUrl: './monaco.component.html',
   styleUrls: ['./monaco.component.scss']
@@ -50,6 +64,9 @@ export class MonacoComponent implements OnInit, OnChanges {
       }
 
       this.editor.updateOptions(options);
+      if (this.editor.getModel()) {
+        this.updatePathDecorations(this.editor);
+      }
     } else {
       this.log.debug("Editor options passed prior to editor init. Cached.");
     }
@@ -64,7 +81,10 @@ export class MonacoComponent implements OnInit, OnChanges {
   public showEditor: boolean;
   public showDiffViewer: boolean;
   private keyBindingSub: Subscription = new Subscription();
-  private diffEditor: monaco.editor.IStandaloneDiffEditor | null ;
+  private diffEditor: monaco.editor.IStandaloneDiffEditor | null;
+  private pathLinkDecorationIds: string[] = [];
+  private pathContentChangeDisposable: any = null;
+  private pathDecorateTimeout: any = null;
 
   constructor(
     private monacoService: MonacoService,
@@ -72,6 +92,7 @@ export class MonacoComponent implements OnInit, OnChanges {
     private languageService: LanguageServerService,
     private appKeyboard: EditorKeybindingService,
     public snackBar: SnackBarService,
+    private dialog: MatDialog,
     @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger,
     @Inject(Angular2InjectionTokens.PLUGIN_DEFINITION) private pluginDefinition: ZLUX.ContainerPluginDefinition,
     @Inject(Angular2InjectionTokens.VIEWPORT_EVENTS) private viewportEvents: Angular2PluginViewportEvents) {
@@ -176,6 +197,7 @@ export class MonacoComponent implements OnInit, OnChanges {
   onMonacoInit(editor) {
     this.editorControl.editor.next(editor);
     this.keyBinds(editor);
+    this.setupPathLinkSupport(editor);
     this.viewportEvents.resized
       .pipe(debounceTime(100) as any)
       .subscribe(()=> {
@@ -194,6 +216,195 @@ export class MonacoComponent implements OnInit, OnChanges {
 
   this.connectToLanguageServer();
   */
+  }
+
+  private setupPathLinkSupport(editor: any): void {
+    this.updatePathDecorations(editor);
+
+    const subscribeContentChanges = () => {
+      if (this.pathContentChangeDisposable) {
+        this.pathContentChangeDisposable.dispose();
+      }
+      this.pathContentChangeDisposable = editor.getModel()?.onDidChangeContent(() => {
+        clearTimeout(this.pathDecorateTimeout);
+        this.pathDecorateTimeout = setTimeout(() => this.updatePathDecorations(editor), 300);
+      });
+    };
+
+    subscribeContentChanges();
+
+    // Re-decorate whenever a different file model is loaded into this editor instance
+    editor.onDidChangeModel(() => {
+      this.pathLinkDecorationIds = [];
+      subscribeContentChanges();
+      this.updatePathDecorations(editor);
+    });
+
+    // Handle Ctrl/Cmd+Click to open recognized strings in the editor
+    editor.onMouseDown((e: any) => {
+      if (!e.event.ctrlKey && !e.event.metaKey) { return; }
+      const position = e.target.position;
+      if (!position) { return; }
+      const model = editor.getModel();
+      if (!model) { return; }
+
+      const options = this._monacoOptions || {};
+      const line = model.getLineContent(position.lineNumber);
+
+      // Check URLs first — must run before path pattern since URLs contain paths
+      if (options.clickLinksUrl !== false) {
+        const urlRegex = new RegExp(URL_PATTERN, 'g');
+        let match: RegExpExecArray | null;
+        while ((match = urlRegex.exec(line)) !== null) {
+          if (position.column >= match.index + 1 && position.column <= match.index + match[0].length + 1) {
+            e.event.preventDefault();
+            this.handleUrlClick(match[0]);
+            return;
+          }
+        }
+      }
+
+      // Check dataset patterns: //'DS.NAME' and DSNAME=DS.NAME
+      if (options.clickLinksDataset !== false) {
+        const dsSlashRegex = new RegExp(DATASET_SLASH_PATTERN, 'g');
+        let match: RegExpExecArray | null;
+        while ((match = dsSlashRegex.exec(line)) !== null) {
+          if (position.column >= match.index + 1 && position.column <= match.index + match[0].length + 1) {
+            e.event.preventDefault();
+            // Strip the //'' wrapper to extract the dataset name
+            this.handleDatasetClick(match[0].substring(3, match[0].length - 1));
+            return;
+          }
+        }
+        const dsnameRegex = new RegExp(DATASET_DSNAME_PATTERN, 'g');
+        while ((match = dsnameRegex.exec(line)) !== null) {
+          if (position.column >= match.index + 1 && position.column <= match.index + match[0].length + 1) {
+            e.event.preventDefault();
+            // Strip the 'DSNAME=' prefix to extract the dataset name
+            this.handleDatasetClick(match[0].substring('DSNAME='.length));
+            return;
+          }
+        }
+      }
+
+      // Check Unix-style file/directory paths
+      if (options.clickLinksFilePath !== false) {
+        const pathRegex = new RegExp(PATH_PATTERN, 'g');
+        let match: RegExpExecArray | null;
+        while ((match = pathRegex.exec(line)) !== null) {
+          if (position.column >= match.index + 1 && position.column <= match.index + match[0].length + 1) {
+            e.event.preventDefault();
+            this.handleFilePathClick(match[0]);
+            return;
+          }
+        }
+      }
+    });
+  }
+
+  private updatePathDecorations(editor: any): void {
+    const model = editor.getModel();
+    if (!model) { return; }
+
+    const options = this._monacoOptions || {};
+    const enableFilePath = options.clickLinksFilePath !== false;
+    const enableDataset = options.clickLinksDataset !== false;
+    const enableUrl = options.clickLinksUrl !== false;
+
+    const newDecorations: monaco.editor.IModelDeltaDecoration[] = [];
+    const lineCount = model.getLineCount();
+
+    // Each tuple: [patternString, enabled]
+    const patterns: [string, boolean][] = [
+      [PATH_PATTERN, enableFilePath],
+      [DATASET_DSNAME_PATTERN, enableDataset],
+      [DATASET_SLASH_PATTERN, enableDataset],
+      [URL_PATTERN, enableUrl]
+    ];
+
+    for (let lineNumber = 1; lineNumber <= lineCount; lineNumber++) {
+      const line = model.getLineContent(lineNumber);
+      for (const [patternStr, enabled] of patterns) {
+        if (!enabled) { continue; }
+        const regex = new RegExp(patternStr, 'g');
+        let match: RegExpExecArray | null;
+        while ((match = regex.exec(line)) !== null) {
+          newDecorations.push({
+            range: new monaco.Range(lineNumber, match.index + 1, lineNumber, match.index + match[0].length + 1),
+            options: {
+              inlineClassName: 'path-link',
+              hoverMessage: { value: 'Ctrl+Click to open' }
+            }
+          });
+        }
+      }
+    }
+
+    this.pathLinkDecorationIds = editor.deltaDecorations(this.pathLinkDecorationIds, newDecorations);
+  }
+
+  // Checks if a Unix path is a file or directory before acting
+  private handleFilePathClick(path: string): void {
+    this.editorControl.getFileMetadata(path).subscribe({
+      next: (response: any) => {
+        if (response && response.directory === true) {
+          const dialogRef = this.dialog.open(ConfirmAction, {
+            data: <DialogData>{
+              title: 'Open Folder',
+              warningMessage: `Navigate the file explorer to folder: ${path}?`
+            }
+          });
+          dialogRef.afterClosed().subscribe((confirmed: boolean) => {
+            if (confirmed) {
+              this.editorControl.openDirectory.next(path);
+            }
+          });
+        } else {
+          this.openPathInEditor(path);
+        }
+      },
+      error: () => {
+        // Metadata unavailable: attempt to open as a file
+        this.openPathInEditor(path);
+      }
+    });
+  }
+
+  private handleDatasetClick(datasetName: string): void {
+    this.log.debug(`Opening dataset from ctrl+click: ${datasetName}`);
+    this.editorControl.openDataset.next({ datasetName: datasetName.toUpperCase() });
+  }
+
+  private handleUrlClick(url: string): void {
+    const dialogRef = this.dialog.open(ConfirmAction, {
+      data: <DialogData>{
+        title: 'Open URL',
+        warningMessage: `Open "${url}" in a new browser tab?`
+      }
+    });
+    dialogRef.afterClosed().subscribe((confirmed: boolean) => {
+      if (confirmed) {
+        window.open(url, '_blank', 'noopener,noreferrer');
+      }
+    });
+  }
+
+  private openPathInEditor(path: string): void {
+    const lastSlash = path.lastIndexOf('/');
+    const fileName = lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+    const directory = lastSlash > 0 ? path.substring(0, lastSlash) : '/';
+
+    const fileNode: ProjectStructure = {
+      id: path,
+      name: fileName,
+      fileName: fileName,
+      path: directory,
+      hasChildren: false,
+      isDataset: false
+    };
+
+    this.log.debug(`Opening file path from ctrl+click: ${path}`);
+    this.editorControl.openFileEmitter.emit(fileNode);
   }
 
   keyBinds(editor: any) {

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
@@ -34,8 +34,10 @@ import { MatDialog } from '@angular/material/dialog';
 import { ConfirmAction, DialogData } from '../../../shared/dialog/confirm-action/confirm-action-component';
 const ReconnectingWebSocket = require('reconnecting-websocket');
 
-// Matches absolute Unix-style paths, e.g. /u/user/file.txt or /etc/zowe/server.yaml
-const PATH_PATTERN = '\\/[a-zA-Z0-9._\\-@+#$~]+(?:\\/[a-zA-Z0-9._\\-@+#$~]+)*';
+// Matches absolute Unix-style paths, e.g. /u/user/file.txt or /etc/zowe/server.yaml.
+// The negative lookbehind prevents matching path segments inside URIs (e.g. safkeyring://host/path)
+// by requiring that the leading / is not preceded by an alphanumeric, path, or URI character.
+const PATH_PATTERN = '(?<![a-zA-Z0-9._\\-@+#$~:/])\\/[a-zA-Z0-9._\\-@+#$~]+(?:\\/[a-zA-Z0-9._\\-@+#$~]+)*';
 // Matches MVS dataset notation: DSNAME=A.B or DSNAME=A.B(MEMBER)
 const DATASET_DSNAME_PATTERN =
   'DSNAME=([A-Z@#$][A-Z0-9@#$-]{0,7}(?:\\.[A-Z@#$][A-Z0-9@#$-]{0,7})+(?:\\([A-Z@#$][A-Z0-9@#$-]{0,7}\\))?)';
@@ -251,14 +253,17 @@ export class MonacoComponent implements OnInit, OnChanges {
       const options = this._monacoOptions || {};
       const line = model.getLineContent(position.lineNumber);
 
-      // Check URLs first — must run before path pattern since URLs contain paths
-      if (options.clickLinksUrl !== false) {
-        const urlRegex = new RegExp(URL_PATTERN, 'g');
+      // Always intercept URL clicks to prevent Monaco's built-in link opener from firing,
+      // regardless of the clickLinksUrl setting. Only show the confirmation dialog when enabled.
+      const urlRegex = new RegExp(URL_PATTERN, 'g');
+      {
         let match: RegExpExecArray | null;
         while ((match = urlRegex.exec(line)) !== null) {
           if (position.column >= match.index + 1 && position.column <= match.index + match[0].length + 1) {
             e.event.preventDefault();
-            this.handleUrlClick(match[0]);
+            if (options.clickLinksUrl !== false) {
+              this.handleUrlClick(match[0]);
+            }
             return;
           }
         }

--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -409,6 +409,21 @@ export const DEFAULT_CONFIG: MonacoConfigItem[] = [
       type: ConfigItemType.array,
       values: ['none','same','indent','deepIndent'],
       default: 'none'
+    },
+    {
+      attribute: 'clickLinksFilePath',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'clickLinksDataset',
+      type: ConfigItemType.boolean,
+      default: true
+    },
+    {
+      attribute: 'clickLinksUrl',
+      type: ConfigItemType.boolean,
+      default: true
     }
 ];
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes

This PR adds Ctrl+Click navigation for recognized strings in the Monaco editor panel. When a user holds Ctrl (Cmd on macOS) and clicks on a highlighted string, it triggers a context-aware action:

- **Unix filesystem paths** (e.g. `/u/user/file.txt`): queries the file metadata to determine whether the path is a file or a directory. Files are opened in a new editor tab; directories prompt the user before navigating the file explorer panel to that path.
- **MVS dataset names** (e.g. `DSNAME=SYS1.LINKLIB`, `//'SYS1.LINKLIB'`, `//'SYS1.PROCLIB(IEFBR14)'`): opens the dataset or dataset member in the editor, reusing the existing `openDataset` flow.
- **HTTP/HTTPS URLs** (e.g. `https://example.com`): prompts the user before opening the URL in a new browser tab, with `noopener,noreferrer` for security.

All three link types are highlighted with an underline decoration and a hover tooltip ("Ctrl+Click to open") so users can discover the feature at a glance. Each behavior is individually controlled by a new boolean setting in the Settings panel, all defaulting to enabled:

| Setting attribute | Settings menu label |
|---|---|
| `clickLinksFilePath` | Click Links File Path |
| `clickLinksDataset` | Click Links Dataset |
| `clickLinksUrl` | Click Links Url |

Settings are persisted to the user's `editorconfig.json` via the existing config service and take effect immediately when toggled.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

### Manual test steps

1. Open the Zowe Desktop and launch the **Editor** app.
2. Open any file whose content contains one or more of the following:
   - A Unix path, e.g. `/etc/zowe/server.yaml`
   - A dataset reference, e.g. `DSNAME=SYS1.LINKLIB` or `//'SYS1.PROCLIB(IEFBR14)'`
   - A URL, e.g. `https://zowe.org`
3. Confirm that each recognized string is **underlined and tinted** differently from surrounding text.
4. Hover over a recognized string — a tooltip reading "Ctrl+Click to open" should appear.

#### File path — file
5. Ctrl+Click a path that resolves to an existing file. Confirm a new editor tab opens for that file.

#### File path — directory
6. Ctrl+Click a path that resolves to a directory. Confirm a confirmation dialog appears asking whether to navigate the file explorer.  
   - Click **Yes** — the file explorer panel should navigate to that directory.  
   - Click **No** or close the dialog — nothing should happen.

#### Dataset / member
7. Ctrl+Click a `DSNAME=` or `//'...'` reference. Confirm the dataset (or member) opens in the editor.

#### URL
8. Ctrl+Click a URL. Confirm a confirmation dialog appears.  
   - Click **Yes** — a new browser tab opens to that URL.  
   - Click **No** or close the dialog — the tab should not open.

#### Settings toggles
9. Open **Settings** in the editor (gear icon / settings tab).
10. Locate **Click Links File Path**, **Click Links Dataset**, and **Click Links Url** checkboxes.
11. Uncheck one setting at a time and confirm the corresponding decoration disappears and Ctrl+Click no longer triggers that action.
12. Re-check and confirm behavior is restored. Click **Save** and reload the editor — confirm the saved state is preserved.

## Further comments

The feature reuses the existing `openFileEmitter`, `openDataset`, `openDirectory`, `getFileMetadata`, and `ConfirmAction` dialog — no new services or dialog components were introduced. The patterns and per-type opt-out logic live entirely in `monaco.component.ts`, alongside the existing `setupPathLinkSupport`, `updatePathDecorations`, and new handler methods. Decoration refresh is debounced (300 ms) on content change and also fires on model swap, so performance impact during active editing should be minimal.
