### PR TITLE
Fix language list items getting duplicated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zlux Editor Changelog
 
+## `3.5.0`
+- Bugfix: Fixed duplicate language entries appearing in the editor toolbar language list when opening the editor multiple times in the same browser window.
+
 ## `3.4.0`
 
 - Enhancement: Re-enabled JCL submit via submit menu and ability to view submitted job via JES Explorer desktop app.

--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -419,11 +419,12 @@ export class MonacoConfig {
   onLoad() {
     let self = this;
     // This step only happens once per editor load, not once per file load. It happens before language menu is generated
-    monaco.languages.register(BPXPRM_LANG);
-    monaco.languages.register(HLASM_LANG);
-    monaco.languages.register(IEASYS_LANG);
-    monaco.languages.register(JCL_LANG);
-    monaco.languages.register(REXX_LANG);
+    const registeredIds = new Set(monaco.languages.getLanguages().map(l => l.id));
+    if (!registeredIds.has(BPXPRM_LANG.id)) { monaco.languages.register(BPXPRM_LANG); }
+    if (!registeredIds.has(HLASM_LANG.id)) { monaco.languages.register(HLASM_LANG); }
+    if (!registeredIds.has(IEASYS_LANG.id)) { monaco.languages.register(IEASYS_LANG); }
+    if (!registeredIds.has(JCL_LANG.id)) { monaco.languages.register(JCL_LANG); }
+    if (!registeredIds.has(REXX_LANG.id)) { monaco.languages.register(REXX_LANG); }
 
     monaco.languages.setMonarchTokensProvider('bpxprm', <any>BPXPRM_HILITE);
     monaco.languages.setMonarchTokensProvider('hlasm', <any>HLASM_HILITE);

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -268,7 +268,10 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
   }
 
   public registerLanguage(languageDefinition, highlighter?:any) {
-    monaco.languages.register(languageDefinition);
+    const alreadyRegistered = monaco.languages.getLanguages().some(l => l.id === languageDefinition.id);
+    if (!alreadyRegistered) {
+      monaco.languages.register(languageDefinition);
+    }
     if (highlighter) {
       monaco.languages.setMonarchTokensProvider(languageDefinition.id, highlighter);
     }


### PR DESCRIPTION
<img width="290" height="389" alt="image" src="https://github.com/user-attachments/assets/8c67d185-da80-4d5c-b8fe-d1c2f334a9ef" />


<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR addresses Issue: https://github.com/zowe/zlux/issues/837

The editor toolbar language selection menu could display duplicate entries for custom languages (JCL, HLASM, REXX, BPXPRM, IEASYS, and any test language) when the Zowe Editor plugin was opened more than once in the same browser window.

The root cause is that Monaco's language registry is a global singleton that persists for the entire browser session. Every time a new editor instance is created, `MonacoConfig.onLoad()` registered the custom languages again via `monaco.languages.register()`, appending duplicate entries to the global list. The toolbar language menu is built from `monaco.languages.getLanguages()`, so it reflected all the duplicates.

Two guards were added:
- In `monaco.config.ts` `onLoad()`: snapshot the currently registered language IDs into a `Set` before registering BPXPRM, HLASM, IEASYS, JCL, and REXX, and skip any that are already present.
- In `editor-control.service.ts` `registerLanguage()`: check `monaco.languages.getLanguages()` for the language ID before calling `monaco.languages.register()`, skipping the registration if the language is already known to Monaco.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

**To reproduce the bug:**
1. Open the Zowe Desktop in a browser.
2. Open the Zowe Editor plugin.
3. Close the Editor without refreshing the page.
4. Open the Zowe Editor plugin again.
5. Open any file. Observe the Language menu in the toolbar — custom languages (e.g. JCL, HLASM) will appear twice (or more for each additional open).
