### PR TITLE
HLASM hover-help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## `3.5.0`
 
-- Enhancement: Added CEEDUMP language mode for the Monaco editor. Files named `CEEDUMP.*` are automatically detected. The mode provides syntax highlighting for section headers, register names, CEE message identifiers, memory storage dumps, and EBCDIC-decoded character columns. 32-bit and 64-bit hex addresses are colored by byte significance to aid in pointer analysis. Hovering over keywords, section headers, register names (GPR0–15, FPR, VR), and CEE message IDs shows contextual diagnostic documentation.
+- Enhancement: Added CEEDUMP language mode for the Monaco editor. Files named `CEEDUMP.*` are automatically detected. The mode provides syntax highlighting for section headers, register names, CEE message identifiers, memory storage dumps, and EBCDIC-decoded character columns. 32-bit and 64-bit hex addresses are colored by byte significance to aid in pointer analysis. Hovering over keywords, section headers, register names (GPR0-15, FPR, VR), and CEE message IDs shows contextual diagnostic documentation.
+- Enhancement: HLASM language mode now has hover-help and improved syntax highlighting
 
 ## `3.4.0`
 

--- a/webClient/src/app/editor/code-editor/monaco/hiliters/ceedump.ts
+++ b/webClient/src/app/editor/code-editor/monaco/hiliters/ceedump.ts
@@ -30,11 +30,11 @@
 /** CEE message IDs with human-readable descriptions used by the hover provider. */
 export const CEE_MESSAGES: Record<string, string> = {
   CEE0198S: 'A thread was killed because a condition (exception) was raised but no condition handler chose to handle or recover from it. Look at the Original Condition in the CIB for the root cause.',
-  CEE3201S: 'Abend 0C1 — the CPU tried to execute a bit pattern that is not a valid z/Architecture instruction. Often caused by branching into data, a corrupted function pointer, or executing storage that was never initialized.',
-  CEE3202S: 'Abend 0C2 — the program tried to run a supervisor-state (privileged) instruction while in problem (user) state. Almost always indicates a code corruption or incorrect branch target.',
-  CEE3204S: 'Abend 0C4 — the program touched memory it is not allowed to access. Common causes: null pointer dereference (address 0), use-after-free, buffer overrun into a read-only page, or access to another address space.',
-  CEE3206S: 'Abend 0C6 — an instruction received an operand address that does not meet its alignment requirement (e.g. a fullword operation on an odd address). Usually indicates a corrupted pointer or incorrect offset arithmetic.',
-  CEE3209S: 'Abend 0C9 — integer division by zero or a quotient that overflows the destination register. Check the divisor in the operands of the failing instruction shown by the PSW.',
+  CEE3201S: 'Abend 0C1 -- the CPU tried to execute a bit pattern that is not a valid z/Architecture instruction. Often caused by branching into data, a corrupted function pointer, or executing storage that was never initialized.',
+  CEE3202S: 'Abend 0C2 -- the program tried to run a supervisor-state (privileged) instruction while in problem (user) state. Almost always indicates a code corruption or incorrect branch target.',
+  CEE3204S: 'Abend 0C4 -- the program touched memory it is not allowed to access. Common causes: null pointer dereference (address 0), use-after-free, buffer overrun into a read-only page, or access to another address space.',
+  CEE3206S: 'Abend 0C6 -- an instruction received an operand address that does not meet its alignment requirement (e.g. a fullword operation on an odd address). Usually indicates a corrupted pointer or incorrect offset arithmetic.',
+  CEE3209S: 'Abend 0C9 -- integer division by zero or a quotient that overflows the destination register. Check the divisor in the operands of the failing instruction shown by the PSW.',
   CEE3250C: 'A program check or explicit ABEND macro caused an abnormal termination with the shown system (Sxxx) or user (Uxxx) abend code. The reason code provides additional detail from the subsystem that issued the abend.',
   CEE3501S: 'Language Environment could not load the named shared library (DLL / .so). Check that the library exists on the LIBPATH, that its file permissions are correct, and that it was built for the right AMODE.',
   CEE3588S: 'A 31-bit caller tried to call a function inside a 64-bit DLL (or vice versa) without a proper AMODE-switching stub. The two modules need a compatible linkage shim or must be rebuilt to the same addressing mode.',
@@ -50,57 +50,57 @@ export const CEE_MESSAGES: Record<string, string> = {
  * Keys are the option name exactly as it appears in the dump (uppercase).
  */
 export const CEE_RUNOPTS: Record<string, string> = {
-  ABPERC: '**ABPERC** — Percentage of recoverable errors to tolerate before LE forces termination. `NONE` (default) means zero tolerance. Rarely changed; a non-zero value can mask repeated failures.',
-  ABTERMENC: '**ABTERMENC** — How LE reports termination to z/OS: as an abend code (`ABEND`, default) or a return code (`RETCODE`). Affects whether JCL COND checks on step abend will fire.',
-  ALL31: '**ALL31** — When `ON`, constrains all routines to 31-bit addressing even if compiled 64-bit. Required when mixing with 31-bit-only DLLs or system services.',
-  ANYHEAP: '**ANYHEAP** — Sizes the 31-bit heap for allocations requested with the `ANYWHERE` location qualifier. Relevant only to programs that do not use HEAP64.',
-  BELOWHEAP: '**BELOWHEAP** — Sizes the heap below the 16 MB line (24-bit addressable storage). Needed when calling VSAM, BSAM, or other interfaces that require 24-bit addresses.',
-  CBLOPTS: '**CBLOPTS** — Enables COBOL-specific LE runtime behaviors. Must match the compile-time CBLOPTS setting; a mismatch can produce unpredictable COBOL behavior.',
-  CBLPSHPOP: '**CBLPSHPOP** — Controls whether COBOL PUSH/POP ENVIRONMENT statements save and restore LE runtime options.',
-  CBLQDA: '**CBLQDA** — Enables the COBOL Qualified Data Area DSA layout required by certain LE-callable services. Rarely changed.',
-  CEEDUMP: '**CEEDUMP** — Controls CEEDUMP output file allocation: max lines per dump, SYSOUT class, and spool-release behavior. Ignored if the CEEDUMP DD is pre-allocated in JCL.',
-  CHECK: '**CHECK** — When `ON`, LE adds guard bytes around heap blocks and validates them on every free. Detects overruns and double-frees. Enable when chasing intermittent 0C4s in heap-intensive code; significant overhead.',
-  COUNTRY: '**COUNTRY** — Two-character ISO country code for LE NLS output (date/time format, numeric punctuation). Does not affect application-level globalization.',
-  DEPTHCONDLMT: '**DEPTHCONDLMT** — Maximum nesting depth for recursive condition handling. LE abends if this depth is exceeded. Default 10; `0` is unlimited (dangerous).',
-  DYNDUMP: '**DYNDUMP** — Whether LE also requests a system dump (SVCDUMP/TDUMP) alongside the CEEDUMP. `NODYNAMIC` (default) means CEEDUMP only. A full system dump requires RACF authority and is much larger.',
-  ENVAR: '**ENVAR** — Preset z/OS UNIX environment variables (e.g. `LIBPATH`, `TZ`) before `main()` runs, without modifying the shell profile.',
-  ERRCOUNT: '**ERRCOUNT** — Maximum recoverable errors before LE terminates the enclave. `0` (default) is unlimited. A non-zero value prevents infinite condition-handler retry loops.',
-  ERRUNIT: '**ERRUNIT** — Fortran logical unit number for LE error messages. Ignored for non-Fortran programs.',
-  FILEHIST: '**FILEHIST** — Enables file open/close event tracking. The history is included in the CEEDUMP. Useful for diagnosing file-not-found or already-open errors in COBOL and Fortran I/O.',
-  FILETAG: '**FILETAG** — Controls automatic EBCDIC↔code-page conversion for tagged HFS/zFS files. If a program reads files as garbage, verify this option and the file\'s tag are consistent.',
-  HEAP: '**HEAP** — Sizes the primary 31-bit heap (below the 2 GB bar). If the job abends with out-of-storage, increase the initial size and growth increment here.',
-  HEAP64: '**HEAP64** — Sizes the primary 64-bit heap (above the 2 GB bar). The default allocation area for 64-bit programs. If `malloc` returns NULL or a 0C4 follows a large allocation, increase these values.',
-  HEAPCHK: '**HEAPCHK** — Activates heap boundary-tag checking on every allocation and free. Identifies heap overruns and use-after-free bugs. High overhead; test environments only.',
-  HEAPPOOLS: '**HEAPPOOLS** — Configures fixed-size pool buckets for the 31-bit heap. Reduces fragmentation for programs that allocate many small same-size objects. Disable when debugging heap corruption — pools can delay the fault.',
-  HEAPPOOLS64: '**HEAPPOOLS64** — 64-bit equivalent of HEAPPOOLS. Same behavior but covers the above-the-bar heap.',
-  HEAPZONES: '**HEAPZONES** — Partitions the heap into isolated zones. A corrupted or exhausted zone can be identified without contaminating others.',
-  INFOMSGFILTER: '**INFOMSGFILTER** — Suppresses repeated LE informational messages that match the filter. Does not suppress warnings or errors.',
-  IOHEAP64: '**IOHEAP64** — Sizes the heap used by LE buffered I/O internally (stdio buffers, record management). Kept separate from the application heap. Increase if the program abends with a storage exception during heavy I/O.',
-  LIBHEAP64: '**LIBHEAP64** — Sizes the heap reserved exclusively for LE runtime internals (thread control blocks, condition handler chains). Corruption here indicates an LE runtime bug rather than application code.',
-  LIBSTACK: '**LIBSTACK** — Sizes the stack used by LE runtime routines running on behalf of the application. Rarely needs changing unless LE internal routines overflow.',
-  MSGFILE: '**MSGFILE** — Redirects LE message output to a named DD instead of SYSOUT.',
-  NATLANG: '**NATLANG** — National language for LE message text. `ENU` = US English. Changing requires the corresponding NLS catalog to be installed.',
-  NOTEST: '**NOTEST / TEST** — Controls z/OS Debugger (Debug Tool) entry. `NOTEST(ALL,...)` disables all debug entry points. Use `TEST(...)` to enable interactive debugging; requires the debugger and a `TEST`/`DEBUG` compile.',
-  OCSTATUS: '**OCSTATUS** — When `ON`, LE reports open files and sockets at abnormal termination. Useful for diagnosing resource leaks that survive a crash.',
-  PAGEFRAMESIZE: '**PAGEFRAMESIZE** — Preferred page frame size for 31-bit regions (`4K`, `1M`). Large pages reduce TLB pressure for large working sets but require system authorization.',
-  PAGEFRAMESIZE64: '**PAGEFRAMESIZE64** — Preferred page frame size for 64-bit regions. Large pages can improve throughput for programs with large heaps or code footprints.',
-  PLITASKCOUNT: '**PLITASKCOUNT** — Maximum concurrent PL/I TASK/ATTACH tasks. PL/I only.',
-  POSIX: '**POSIX** — When `ON`, establishes a z/OS UNIX POSIX process (`sigaction`, `pthread_create`, `fork`, etc.). Required for C/C++ programs using UNIX APIs. `OFF` runs as a traditional MVS batch job.',
-  PROFILE: '**PROFILE** — When `ON`, LE reads runtime options from a data set at startup. Allows changing options without relinking or modifying the PARM string.',
-  RPTOPTS: '**RPTOPTS** — When `ON`, LE prints the effective runtime option settings at job termination — the list you see at the bottom of this file. Essential for confirming which options were actually active during the crash.',
-  RPTSTG: '**RPTSTG** — When `ON`, LE prints heap and stack storage usage statistics at termination. Use to right-size HEAP/STACK options or detect storage leaks.',
-  STACK: '**STACK** — Sizes the call stack (DSA chain) for 31-bit programs. A 0C4 near GPR13-relative addressing often means the stack overflowed; increase the max here.',
-  STACK64: '**STACK64** — Sizes the call stack for 64-bit programs. Recursive algorithms and large local arrays may require a larger max. Stack overflow corrupts the DSA chain and produces garbled tracebacks.',
-  STORAGE: '**STORAGE** — Fill patterns written to storage on allocation and free. `NONE` (default) disables all filling. Setting patterns (e.g. `F4` on alloc, `FE` on free) is the fastest way to expose uninitialized-memory and use-after-free bugs.',
-  TERMTHDACT: '**TERMTHDACT** — What LE does when a thread terminates abnormally:\n- `UADUMP` — write a full CEEDUMP (produces this file)\n- `TRACE` — condensed traceback to SYSOUT only\n- `QUIET` — suppress all output\n- `DUMP` — CEEDUMP plus a system dump\n\nIf no CEEDUMP exists for a crash, this was likely `TRACE` or `QUIET`.',
-  THREADHEAP: '**THREADHEAP** — Per-thread private heap size. Increases reduce contention on the shared enclave heap in heavily multi-threaded programs.',
-  THREADSTACK: '**THREADSTACK** — Controls whether each 31-bit thread gets a private stack (`ON`) or shares the enclave stack pool (`OFF`).',
-  THREADSTACK64: '**THREADSTACK64** — Controls whether each 64-bit thread gets a private stack (`ON`) or shares the enclave stack pool (`OFF`). A tight max causes stack overflow in recursive or array-heavy threads.',
-  TRACE: '**TRACE** — LE internal trace collection. `OFF` by default. Produces very large output; enable only at IBM support\'s request.',
-  TRAP: '**TRAP** — Whether LE intercepts hardware program checks. `ON` (default) catches program checks, invokes condition handlers, and produces this CEEDUMP. `OFF` bypasses LE entirely — crashes produce system dumps but no CEEDUMPs.',
-  UPSI: '**UPSI** — Sets the 8-bit User Program Switch Indicator byte used by COBOL and Fortran programs. Rarely relevant to crashes.',
-  VCTRSAVE: '**VCTRSAVE** — Whether vector registers VR0–VR31 are saved across LE-managed calls. `YES` required if SIMD code runs on multiple threads simultaneously.',
-  XUFLOW: '**XUFLOW** — Fortran only. `ON` raises an LE condition on floating-point underflow instead of silently returning zero. Useful for detecting precision loss in numerical code.',
+  ABPERC: '**ABPERC** -- Percentage of recoverable errors to tolerate before LE forces termination. `NONE` (default) means zero tolerance. Rarely changed; a non-zero value can mask repeated failures.',
+  ABTERMENC: '**ABTERMENC** -- How LE reports termination to z/OS: as an abend code (`ABEND`, default) or a return code (`RETCODE`). Affects whether JCL COND checks on step abend will fire.',
+  ALL31: '**ALL31** -- When `ON`, constrains all routines to 31-bit addressing even if compiled 64-bit. Required when mixing with 31-bit-only DLLs or system services.',
+  ANYHEAP: '**ANYHEAP** -- Sizes the 31-bit heap for allocations requested with the `ANYWHERE` location qualifier. Relevant only to programs that do not use HEAP64.',
+  BELOWHEAP: '**BELOWHEAP** -- Sizes the heap below the 16 MB line (24-bit addressable storage). Needed when calling VSAM, BSAM, or other interfaces that require 24-bit addresses.',
+  CBLOPTS: '**CBLOPTS** -- Enables COBOL-specific LE runtime behaviors. Must match the compile-time CBLOPTS setting; a mismatch can produce unpredictable COBOL behavior.',
+  CBLPSHPOP: '**CBLPSHPOP** -- Controls whether COBOL PUSH/POP ENVIRONMENT statements save and restore LE runtime options.',
+  CBLQDA: '**CBLQDA** -- Enables the COBOL Qualified Data Area DSA layout required by certain LE-callable services. Rarely changed.',
+  CEEDUMP: '**CEEDUMP** -- Controls CEEDUMP output file allocation: max lines per dump, SYSOUT class, and spool-release behavior. Ignored if the CEEDUMP DD is pre-allocated in JCL.',
+  CHECK: '**CHECK** -- When `ON`, LE adds guard bytes around heap blocks and validates them on every free. Detects overruns and double-frees. Enable when chasing intermittent 0C4s in heap-intensive code; significant overhead.',
+  COUNTRY: '**COUNTRY** -- Two-character ISO country code for LE NLS output (date/time format, numeric punctuation). Does not affect application-level globalization.',
+  DEPTHCONDLMT: '**DEPTHCONDLMT** -- Maximum nesting depth for recursive condition handling. LE abends if this depth is exceeded. Default 10; `0` is unlimited (dangerous).',
+  DYNDUMP: '**DYNDUMP** -- Whether LE also requests a system dump (SVCDUMP/TDUMP) alongside the CEEDUMP. `NODYNAMIC` (default) means CEEDUMP only. A full system dump requires RACF authority and is much larger.',
+  ENVAR: '**ENVAR** -- Preset z/OS UNIX environment variables (e.g. `LIBPATH`, `TZ`) before `main()` runs, without modifying the shell profile.',
+  ERRCOUNT: '**ERRCOUNT** -- Maximum recoverable errors before LE terminates the enclave. `0` (default) is unlimited. A non-zero value prevents infinite condition-handler retry loops.',
+  ERRUNIT: '**ERRUNIT** -- Fortran logical unit number for LE error messages. Ignored for non-Fortran programs.',
+  FILEHIST: '**FILEHIST** -- Enables file open/close event tracking. The history is included in the CEEDUMP. Useful for diagnosing file-not-found or already-open errors in COBOL and Fortran I/O.',
+  FILETAG: '**FILETAG** -- Controls automatic EBCDIC<->code-page conversion for tagged HFS/zFS files. If a program reads files as garbage, verify this option and the file\'s tag are consistent.',
+  HEAP: '**HEAP** -- Sizes the primary 31-bit heap (below the 2 GB bar). If the job abends with out-of-storage, increase the initial size and growth increment here.',
+  HEAP64: '**HEAP64** -- Sizes the primary 64-bit heap (above the 2 GB bar). The default allocation area for 64-bit programs. If `malloc` returns NULL or a 0C4 follows a large allocation, increase these values.',
+  HEAPCHK: '**HEAPCHK** -- Activates heap boundary-tag checking on every allocation and free. Identifies heap overruns and use-after-free bugs. High overhead; test environments only.',
+  HEAPPOOLS: '**HEAPPOOLS** -- Configures fixed-size pool buckets for the 31-bit heap. Reduces fragmentation for programs that allocate many small same-size objects. Disable when debugging heap corruption -- pools can delay the fault.',
+  HEAPPOOLS64: '**HEAPPOOLS64** -- 64-bit equivalent of HEAPPOOLS. Same behavior but covers the above-the-bar heap.',
+  HEAPZONES: '**HEAPZONES** -- Partitions the heap into isolated zones. A corrupted or exhausted zone can be identified without contaminating others.',
+  INFOMSGFILTER: '**INFOMSGFILTER** -- Suppresses repeated LE informational messages that match the filter. Does not suppress warnings or errors.',
+  IOHEAP64: '**IOHEAP64** -- Sizes the heap used by LE buffered I/O internally (stdio buffers, record management). Kept separate from the application heap. Increase if the program abends with a storage exception during heavy I/O.',
+  LIBHEAP64: '**LIBHEAP64** -- Sizes the heap reserved exclusively for LE runtime internals (thread control blocks, condition handler chains). Corruption here indicates an LE runtime bug rather than application code.',
+  LIBSTACK: '**LIBSTACK** -- Sizes the stack used by LE runtime routines running on behalf of the application. Rarely needs changing unless LE internal routines overflow.',
+  MSGFILE: '**MSGFILE** -- Redirects LE message output to a named DD instead of SYSOUT.',
+  NATLANG: '**NATLANG** -- National language for LE message text. `ENU` = US English. Changing requires the corresponding NLS catalog to be installed.',
+  NOTEST: '**NOTEST / TEST** -- Controls z/OS Debugger (Debug Tool) entry. `NOTEST(ALL,...)` disables all debug entry points. Use `TEST(...)` to enable interactive debugging; requires the debugger and a `TEST`/`DEBUG` compile.',
+  OCSTATUS: '**OCSTATUS** -- When `ON`, LE reports open files and sockets at abnormal termination. Useful for diagnosing resource leaks that survive a crash.',
+  PAGEFRAMESIZE: '**PAGEFRAMESIZE** -- Preferred page frame size for 31-bit regions (`4K`, `1M`). Large pages reduce TLB pressure for large working sets but require system authorization.',
+  PAGEFRAMESIZE64: '**PAGEFRAMESIZE64** -- Preferred page frame size for 64-bit regions. Large pages can improve throughput for programs with large heaps or code footprints.',
+  PLITASKCOUNT: '**PLITASKCOUNT** -- Maximum concurrent PL/I TASK/ATTACH tasks. PL/I only.',
+  POSIX: '**POSIX** -- When `ON`, establishes a z/OS UNIX POSIX process (`sigaction`, `pthread_create`, `fork`, etc.). Required for C/C++ programs using UNIX APIs. `OFF` runs as a traditional MVS batch job.',
+  PROFILE: '**PROFILE** -- When `ON`, LE reads runtime options from a data set at startup. Allows changing options without relinking or modifying the PARM string.',
+  RPTOPTS: '**RPTOPTS** -- When `ON`, LE prints the effective runtime option settings at job termination -- the list you see at the bottom of this file. Essential for confirming which options were actually active during the crash.',
+  RPTSTG: '**RPTSTG** -- When `ON`, LE prints heap and stack storage usage statistics at termination. Use to right-size HEAP/STACK options or detect storage leaks.',
+  STACK: '**STACK** -- Sizes the call stack (DSA chain) for 31-bit programs. A 0C4 near GPR13-relative addressing often means the stack overflowed; increase the max here.',
+  STACK64: '**STACK64** -- Sizes the call stack for 64-bit programs. Recursive algorithms and large local arrays may require a larger max. Stack overflow corrupts the DSA chain and produces garbled tracebacks.',
+  STORAGE: '**STORAGE** -- Fill patterns written to storage on allocation and free. `NONE` (default) disables all filling. Setting patterns (e.g. `F4` on alloc, `FE` on free) is the fastest way to expose uninitialized-memory and use-after-free bugs.',
+  TERMTHDACT: '**TERMTHDACT** -- What LE does when a thread terminates abnormally:\n- `UADUMP` -- write a full CEEDUMP (produces this file)\n- `TRACE` -- condensed traceback to SYSOUT only\n- `QUIET` -- suppress all output\n- `DUMP` -- CEEDUMP plus a system dump\n\nIf no CEEDUMP exists for a crash, this was likely `TRACE` or `QUIET`.',
+  THREADHEAP: '**THREADHEAP** -- Per-thread private heap size. Increases reduce contention on the shared enclave heap in heavily multi-threaded programs.',
+  THREADSTACK: '**THREADSTACK** -- Controls whether each 31-bit thread gets a private stack (`ON`) or shares the enclave stack pool (`OFF`).',
+  THREADSTACK64: '**THREADSTACK64** -- Controls whether each 64-bit thread gets a private stack (`ON`) or shares the enclave stack pool (`OFF`). A tight max causes stack overflow in recursive or array-heavy threads.',
+  TRACE: '**TRACE** -- LE internal trace collection. `OFF` by default. Produces very large output; enable only at IBM support\'s request.',
+  TRAP: '**TRAP** -- Whether LE intercepts hardware program checks. `ON` (default) catches program checks, invokes condition handlers, and produces this CEEDUMP. `OFF` bypasses LE entirely -- crashes produce system dumps but no CEEDUMPs.',
+  UPSI: '**UPSI** -- Sets the 8-bit User Program Switch Indicator byte used by COBOL and Fortran programs. Rarely relevant to crashes.',
+  VCTRSAVE: '**VCTRSAVE** -- Whether vector registers VR0-VR31 are saved across LE-managed calls. `YES` required if SIMD code runs on multiple threads simultaneously.',
+  XUFLOW: '**XUFLOW** -- Fortran only. `ON` raises an LE condition on floating-point underflow instead of silently returning zero. Useful for detecting precision loss in numerical code.',
 };
 
 /** Terms with hover documentation for the CEEDUMP language. */
@@ -108,57 +108,57 @@ export const CEEDUMP_HOVER_DOCS: Record<string, string> = {
   ASID: '**Address Space IDentifier (ASID)**\n\nA 16-bit number that z/OS uses to tag each address space. Two addresses with different ASIDs refer to completely separate virtual memory, even if the numeric values are identical. Cross-memory storage accesses require authorization; unauthorized references produce a 0C4 protection exception.',
   PID: '**Process ID (PID)**\n\nThe z/OS UNIX process number for the failing job step. Use this to find the matching entry in `ps` output or in `/proc`, and to correlate with syslog, operator messages, and other CEEDUMPs written during the same run. The Parent PID on the same line shows which process spawned this one.',
   DSA: '**Dynamic Storage Area (DSA)**\n\nLanguage Environment\'s equivalent of a stack frame. Each call pushes a new DSA; each return pops it. The DSA holds the routine\'s saved registers, local variables, and the linkage pointers (BKC, FWC, NAB) that chain the frames together. A corrupted DSA chain is a common cause of garbled tracebacks.',
-  CIB: '**Condition Information Block (CIB)**\n\nThe snapshot LE takes at the exact instant an exception fires. It records the failing PSW, all 16 GPRs, the interruption code, and the feedback token identifying the condition. When diagnosing a crash, the CIB is the ground truth — the registers in the Parameters section were captured later and may reflect cleanup code.',
+  CIB: '**Condition Information Block (CIB)**\n\nThe snapshot LE takes at the exact instant an exception fires. It records the failing PSW, all 16 GPRs, the interruption code, and the feedback token identifying the condition. When diagnosing a crash, the CIB is the ground truth -- the registers in the Parameters section were captured later and may reflect cleanup code.',
   PSW: '**Program Status Word (PSW)**\n\nThe CPU register that drives instruction fetch. The low-order bits give the next instruction address; other bits encode AMODE (24/31/64), the condition code, and interrupt masks. Subtracting the ILC from the PSW address gives the address of the instruction that *caused* the interruption.',
-  ILC: '**Instruction Length Code (ILC)**\n\nEncodes how many bytes the faulting instruction occupied: 1 = 2 bytes, 2 = 4 bytes, 3 = 6 bytes. Subtract `ILC × 2` from the PSW instruction address to get the address of the instruction that triggered the program check. That address should match column E Addr in the Traceback.',
+  ILC: '**Instruction Length Code (ILC)**\n\nEncodes how many bytes the faulting instruction occupied: 1 = 2 bytes, 2 = 4 bytes, 3 = 6 bytes. Subtract `ILC * 2` from the PSW instruction address to get the address of the instruction that triggered the program check. That address should match column E Addr in the Traceback.',
   NAB: '**Next Available Byte (NAB)**\n\nPoints to the first unused byte at the top of the current stack frame, playing the role of a stack pointer. When a routine is entered its NAB is advanced past its local storage. A NAB that points into code or read-only storage often signals stack overflow or a corrupted frame.',
-  BKC: '**Back Chain (BKC)**\n\nStored at offset +8 in each DSA, this pointer leads to the *caller\'s* DSA. LE walks BKC links to build the Traceback. If BKC is 0, null, or points into nonsense storage, the traceback will be truncated — a sign that the stack has been overwritten.',
+  BKC: '**Back Chain (BKC)**\n\nStored at offset +8 in each DSA, this pointer leads to the *caller\'s* DSA. LE walks BKC links to build the Traceback. If BKC is 0, null, or points into nonsense storage, the traceback will be truncated -- a sign that the stack has been overwritten.',
   FWC: '**Forward Chain (FWC)**\n\nThe mirror of BKC: stored in the caller\'s DSA, it points to the *callee\'s* DSA. LE uses the FWC to navigate downward through live frames. Mismatched BKC/FWC pairs indicate partial stack corruption.',
   PNAB: '**Previous Next Available Byte (PNAB)**\n\nThe NAB value that was current in the *calling* routine before it made the call. Saved in the DSA so it can be restored when the callee returns or when the stack is unwound during condition handling.',
   'UPSTACK DSA': '**Upstack DSA**\n\nThe callee reserves its own storage by bumping the NAB upward. This is the XPLINK convention and is typical for optimized C/C++ on z/OS. Because the callee owns its frame, register saves and local variables sit above the caller\'s NAB rather than below it as in traditional linkage.',
   'XPLINK DSA': '**XPLINK (Extra Performance Linkage) DSA**\n\nA streamlined calling convention used by z/OS XL C/C++ with optimization. Frames are variable-length and callee-allocated, branches replace traditional BALR/BASSM calls, and parameters are passed in registers rather than a list. XPLINK and non-XPLINK code can coexist but require a linkage stub at the boundary.',
-  'GPREG STORAGE': '**GPREG Storage**\n\nFor each GPR, the dump prints 64 bytes centered on the address the register held. The three lines show the 32 bytes *before* (`-0020`), the 32 bytes *at* (`+0000`), and the 32 bytes *after* (`+0020`) the register value. This lets you see what the register was pointing into: a string, a control block, code, or garbage — without having to look up addresses manually.',
-  Traceback: '**Traceback**\n\nThe call stack at the time of the dump, one row per frame, outermost call last. Column guide:\n- **DSA** — frame number (1 = deepest / most recent call)\n- **Entry** — routine name or entry point label\n- **E** — `+` marks the frame where the exception fired\n- **Offset** — distance from the entry point to the failing or call instruction\n- **Statement** — source line number (requires debug symbols)\n- **Load Mod** — the executable or DLL that owns this frame\n- **Program Unit** — the compilation unit (source file)\n- **Service** — the LE or compiler service level of the module\n- **Status** — `Call` (normal), `Exception` (fault here), or `Error`',
-  'Condition Information for Active Routines': '**Condition Information for Active Routines**\n\nOne entry per routine that was actively handling a condition when the dump was taken. Each entry shows two conditions:\n- **Current Condition** — what LE is processing right now (often CEE0198S "unhandled")\n- **Original Condition** — the root-cause exception that started the chain\n\nAlways start diagnosis from the Original Condition and its associated machine state.',
-  'Parameters, Registers, and Variables for Active Routines': '**Parameters, Registers, and Variables**\n\nPer-routine diagnostic detail. For each active frame:\n- Incoming parameter values (types decoded from debug info)\n- GPR/FPR/VR contents *saved on entry* to that routine\n- GPREG storage windows around each saved register\n- Local variable values with types (only when compiled with TEST or DEBUG)\n\nNote: these registers were saved during the prologue, not at the fault point — use the CIB machine state for the exact fault-time register values.',
+  'GPREG STORAGE': '**GPREG Storage**\n\nFor each GPR, the dump prints 64 bytes centered on the address the register held. The three lines show the 32 bytes *before* (`-0020`), the 32 bytes *at* (`+0000`), and the 32 bytes *after* (`+0020`) the register value. This lets you see what the register was pointing into: a string, a control block, code, or garbage -- without having to look up addresses manually.',
+  Traceback: '**Traceback**\n\nThe call stack at the time of the dump, one row per frame, outermost call last. Column guide:\n- **DSA** -- frame number (1 = deepest / most recent call)\n- **Entry** -- routine name or entry point label\n- **E** -- `+` marks the frame where the exception fired\n- **Offset** -- distance from the entry point to the failing or call instruction\n- **Statement** -- source line number (requires debug symbols)\n- **Load Mod** -- the executable or DLL that owns this frame\n- **Program Unit** -- the compilation unit (source file)\n- **Service** -- the LE or compiler service level of the module\n- **Status** -- `Call` (normal), `Exception` (fault here), or `Error`',
+  'Condition Information for Active Routines': '**Condition Information for Active Routines**\n\nOne entry per routine that was actively handling a condition when the dump was taken. Each entry shows two conditions:\n- **Current Condition** -- what LE is processing right now (often CEE0198S "unhandled")\n- **Original Condition** -- the root-cause exception that started the chain\n\nAlways start diagnosis from the Original Condition and its associated machine state.',
+  'Parameters, Registers, and Variables for Active Routines': '**Parameters, Registers, and Variables**\n\nPer-routine diagnostic detail. For each active frame:\n- Incoming parameter values (types decoded from debug info)\n- GPR/FPR/VR contents *saved on entry* to that routine\n- GPREG storage windows around each saved register\n- Local variable values with types (only when compiled with TEST or DEBUG)\n\nNote: these registers were saved during the prologue, not at the fault point -- use the CIB machine state for the exact fault-time register values.',
   'Control Blocks for Active Routines': '**Control Blocks for Active Routines**\n\nRaw hex dumps of the LE internal structures for each active frame: the DSA itself, any CIB attached to it, and linkage fields (BKC, FWC, NAB, FLAGS, member). Useful when the formatted sections look wrong and you need to verify the raw data, or when diagnosing LE internals corruption.',
   'Storage for Active Routines': '**Storage for Active Routines**\n\nThe complete contents of each active DSA printed as a hex+EBCDIC dump, starting at offset +000000. This covers local variables, parameter save areas, and compiler temporaries that may not appear in the decoded Variables section. Look here when a local variable shows as `CCCCCCCC` (uninitialized) in the Variables section.',
   'Information for enclave': '**Enclave**\n\nThe outermost LE runtime container, created when the first LE-managed routine starts. One enclave spans all threads in a process. The enclave name (`main` for a C program, or a COBOL/PL/I program name) appears on this line. Multiple-enclave dumps occur when nested LE environments exist, e.g. a COBOL program calling a C DLL that calls CEE3DMP.',
-  'Information for thread': '**Thread**\n\nAll sections that follow — Traceback, registers, condition info, storage — belong to this single thread, identified by its 16-hex-digit token. In a multi-threaded process each thread gets its own block. The thread token can be matched against `pthread_t` values in running code to identify which thread crashed.',
-  'Registers on Entry to CEE3DMP': '**Registers on Entry to CEE3DMP**\n\nGPR/FPR/VR values at the moment control arrived in CEE3DMP — either because your code called it directly, or because the runtime invoked it in response to an unhandled condition. These are the raw machine registers *before* the dump service has modified anything, making them the most trustworthy snapshot of application state.',
+  'Information for thread': '**Thread**\n\nAll sections that follow -- Traceback, registers, condition info, storage -- belong to this single thread, identified by its 16-hex-digit token. In a multi-threaded process each thread gets its own block. The thread token can be matched against `pthread_t` values in running code to identify which thread crashed.',
+  'Registers on Entry to CEE3DMP': '**Registers on Entry to CEE3DMP**\n\nGPR/FPR/VR values at the moment control arrived in CEE3DMP -- either because your code called it directly, or because the runtime invoked it in response to an unhandled condition. These are the raw machine registers *before* the dump service has modified anything, making them the most trustworthy snapshot of application state.',
   'Fully Qualified Names': '**Fully Qualified Names**\n\nLong names that were truncated in the Traceback table are expanded here. For z/OS UNIX programs this is the full HFS path (e.g. `/usr/lib/libfoo.so`); for batch programs it is the PDS member or data set name. Use these when the short name in the Traceback is ambiguous or shows only a partial path.',
   'Full Service Level': '**Full Service Level**\n\nThe complete PTF/APAR service string for each module in the traceback, beyond what fits in the `Service` column. When opening an IBM PMR or searching for known defects, paste this string to confirm exactly which fix level is installed. A mismatch between the running level and a known fix often explains the failure.',
   'Additional Language Specific Information': '**Additional Language Specific Information**\n\nContent here depends on the source language. For C/C++: `__amrc` errno/errno2, DLL load state, and file I/O error details. For COBOL: file status codes and the COBOL-specific condition handler chain. For PL/I: ONCODE and ON-unit information. If the crash involves I/O or a DLL, this section often contains the specific error code that the standard LE sections do not show.',
   'File Status and Attributes': '**File Status and Attributes**\n\nC/C++ only. One entry per open `FILE*` stream at crash time, showing the file name, open flags (r/w/a/b), current byte offset, and the `ferror`/`feof` state. When a crash happens inside or shortly after a read/write call, check here for an error flag that the application may not have checked.',
   'Inaccessible storage': '**Inaccessible Storage**\n\nThe dump service tried to read memory near this address but received a storage protection interrupt. Typical causes: the register held a null or near-null value, the pointer was never initialized, the object was already freed, or the address belongs to a different address space. This is often the direct symptom of a 0C4 crash.',
-  'CEE3DMP': '**CEE3DMP — Language Environment Dump Service**\n\nThe callable service that writes this file. It can be invoked:\n- Explicitly by application code (`CEE3DMP(title, options, &fc)`)\n- Automatically via the `TERMTHDACT(UADUMP)` runtime option on any unhandled condition\n- Via language-specific wrappers: C `cdump()`, Fortran `SDUMP`, PL/I `PLIDUMP`\n\nThe options string controls which sections appear. Common options: `TRACE`, `BLOCKS`, `STORAGE`, `REGISTERS`, `VARIABLES`, `CONDITION`.',
+  'CEE3DMP': '**CEE3DMP -- Language Environment Dump Service**\n\nThe callable service that writes this file. It can be invoked:\n- Explicitly by application code (`CEE3DMP(title, options, &fc)`)\n- Automatically via the `TERMTHDACT(UADUMP)` runtime option on any unhandled condition\n- Via language-specific wrappers: C `cdump()`, Fortran `SDUMP`, PL/I `PLIDUMP`\n\nThe options string controls which sections appear. Common options: `TRACE`, `BLOCKS`, `STORAGE`, `REGISTERS`, `VARIABLES`, `CONDITION`.',
 };
 
 /**
  * Monarch tokenizer definition for CEEDUMP files.
  *
  * Color tokens used by this tokenizer (define in a Monaco theme):
- *   cee-header         — CEE3DMP version + title banner
- *   cee-page-info      — page, date, ASID, PID metadata
- *   cee-message-id     — CEE message identifiers (e.g. CEE3845I)
- *   cee-section        — major section header labels
- *   cee-sub-section    — sub-section labels within routines
- *   cee-label          — field labels (e.g. "ASID:", "GPR0.....")
- *   cee-register       — register names (GPRn, FPRn, VRn, PSW)
- *   cee-offset         — hex offsets (+000000 / -0020)
- *   cee-mem-byte1      — first byte of a 32-bit hex value
- *   cee-mem-lower3     — lower 3 bytes of a 32-bit hex value
- *   cee-mem64-byte1    — first byte (high byte) of a 64-bit hex value
- *   cee-mem64-high32   — remaining 3 bytes of the high 32-bit word
- *   cee-mem64-midbt    — first byte of the low 32-bit word
- *   cee-mem64-lower3   — lower 3 bytes of the low 32-bit word
- *   cee-wildcard       — inaccessible/unknown address markers (****)
- *   cee-ascii          — EBCDIC decoded characters between | ... |
- *   cee-keyword        — status/attribute keywords (Call, Exception…)
- *   cee-compile-attr   — compile attribute tokens (C/C++, POSIX…)
- *   cee-condition      — condition message text lines
- *   cee-separator      — --- separator lines and page headers
- *   cee-runopt         — runtime option names in the RPTOPTS section (hoverable)
+ *   cee-header         -- CEE3DMP version + title banner
+ *   cee-page-info      -- page, date, ASID, PID metadata
+ *   cee-message-id     -- CEE message identifiers (e.g. CEE3845I)
+ *   cee-section        -- major section header labels
+ *   cee-sub-section    -- sub-section labels within routines
+ *   cee-label          -- field labels (e.g. "ASID:", "GPR0.....")
+ *   cee-register       -- register names (GPRn, FPRn, VRn, PSW)
+ *   cee-offset         -- hex offsets (+000000 / -0020)
+ *   cee-mem-byte1      -- first byte of a 32-bit hex value
+ *   cee-mem-lower3     -- lower 3 bytes of a 32-bit hex value
+ *   cee-mem64-byte1    -- first byte (high byte) of a 64-bit hex value
+ *   cee-mem64-high32   -- remaining 3 bytes of the high 32-bit word
+ *   cee-mem64-midbt    -- first byte of the low 32-bit word
+ *   cee-mem64-lower3   -- lower 3 bytes of the low 32-bit word
+ *   cee-wildcard       -- inaccessible/unknown address markers (****)
+ *   cee-ascii          -- EBCDIC decoded characters between | ... |
+ *   cee-keyword        -- status/attribute keywords (Call, Exception...)
+ *   cee-compile-attr   -- compile attribute tokens (C/C++, POSIX...)
+ *   cee-condition      -- condition message text lines
+ *   cee-separator      -- --- separator lines and page headers
+ *   cee-runopt         -- runtime option names in the RPTOPTS section (hoverable)
  */
 export const CEEDUMP_HILITE = {
   defaultToken: 'default',
@@ -203,7 +203,7 @@ export const CEEDUMP_HILITE = {
       [/^\s+(CIB Address:)\s*/, { token: 'cee-label', next: '@hexValue' }],
       [/^\s+(Current Condition:|Original Condition:|Location:|PSW:|ILC\.\.\.\.\.|Interruption Code\.\.\.\.\.)/, { token: 'cee-sub-section', next: '@conditionText' }],
 
-      // ---- "Storage dump near condition…" lines ----
+      // ---- "Storage dump near condition..." lines ----
       // AMODE 31 uses "location: XXXXXXXX"; AMODE 64 uses "location(XXXXXXXXXXXXXXXX)"
       [/^\s+(Storage dump near condition, beginning at location[:(])/, 'cee-sub-section'],
       [/^\s+(Storage around\s+)(GPR[0-9]+|FPR[0-9]+|FPC|VR[0-9]+)/, ['cee-sub-section', 'cee-register']],
@@ -224,7 +224,7 @@ export const CEEDUMP_HILITE = {
       [/Inaccessible storage\./, 'cee-separator'],
 
       // ---- Runtime option lines (RPTOPTS section at bottom of dump) ----
-      // Format: "   <source-label>   OPTIONNAME(...)" — source label is gray, option name is highlighted
+      // Format: "   <source-label>   OPTIONNAME(...)" -- source label is gray, option name is highlighted
       [/^(\s+(?:IBM-supplied default|Invocation command|Application|Installation default)\s+)([A-Z][A-Z0-9]*)/,
         ['cee-separator', 'cee-runopt']],
 

--- a/webClient/src/app/editor/code-editor/monaco/hiliters/hlasm.ts
+++ b/webClient/src/app/editor/code-editor/monaco/hiliters/hlasm.ts
@@ -481,7 +481,7 @@ export const HLASM_HILITE = {
       [/[=,().*+\-\/]/, 'hlasm-operator'],
 
       // Ordinary symbols and keywords (plain identifier)
-      [/[A-Z$#@][A-Z0-9$#@_]*/, ''],
+      [/[A-Z$#@][A-Z0-9$#_@]*/, ''],
     ],
   }
 };

--- a/webClient/src/app/editor/code-editor/monaco/hiliters/hlasm.ts
+++ b/webClient/src/app/editor/code-editor/monaco/hiliters/hlasm.ts
@@ -449,12 +449,19 @@ export const HLASM_HILITE = {
     ],
 
     operandLine: [
-      // End-of-line remark (after operands, separated by at least one space)
-      [/\s{2,}.*$/, 'hlasm-comment'],
+      // Skip whitespace between mnemonic and operands, then enter operand processing
+      [/\s+/, { token: '', next: '@operandWithComment' }],
+      // Keyword with no operands (end of line)
+      [/$/, { token: '', next: '@popall' }],
+    ],
 
-      // Continuation indicator X in column 72 (end of line)
-      [/X$/, 'hlasm-cont'],
-
+    operandWithComment: [
+      // End of line (empty or only trailing spaces) -- pop back to root
+      [/ *$/, { token: '', next: '@popall' }],
+      // Space after operand content = start of end-of-line comment
+      [/ .*$/, { token: 'hlasm-comment', next: '@popall' }],
+      // Continuation indicator X at end of line
+      [/X$/, { token: 'hlasm-cont', next: '@popall' }],
       { include: '@operandRest' },
     ],
 

--- a/webClient/src/app/editor/code-editor/monaco/hiliters/hlasm.ts
+++ b/webClient/src/app/editor/code-editor/monaco/hiliters/hlasm.ts
@@ -1,54 +1,487 @@
-export const HLASM_HILITE = {
-  // Set defaultToken to invalid to see what you do not tokenize yet
-  // defaultToken: 'invalid',
-  ignoreCase: true,
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
 
-  // The main tokenizer for our languages
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+/**
+ * Monarch tokenizer and hover documentation for IBM High Level Assembler (HLASM) source files.
+ *
+ * HLASM statement layout (fixed-column format):
+ *   Col  1-8  : Name field (label / symbol)
+ *   Col  10-14: Operation field (mnemonic)
+ *   Col  16-71: Operand field
+ *   Col  73-80: Identification / sequence field
+ *
+ * Token classes emitted:
+ *   hlasm-comment     --  full-line comments (col 1 = *) and end-of-line remarks
+ *   hlasm-label       --  name-field symbols and sequence symbols
+ *   hlasm-directive   --  assembler directives (CSECT, DC, DS, EQU, USING, ...)
+ *   hlasm-macro-inst  --  macro and conditional assembly instructions
+ *                      (MACRO, MEND, IF, ENDIF, AIF, AGO, ANOP, GBLA/B/C, ...)
+ *   hlasm-keyword     --  machine instruction mnemonics (LR, ST, BNE, ...)
+ *   hlasm-register    --  register references (R0-R15, Rn notation)
+ *   hlasm-string      --  character literals enclosed in apostrophes
+ *   hlasm-number      --  self-defining terms and hex literals (X'...', B'...', C'...')
+ *   hlasm-operator    --  = , ( ) + - * / . notation
+ *   hlasm-variable    --  variable symbols (&name)
+ *   hlasm-seq         --  sequence symbols (.name)
+ *   hlasm-cont        --  continuation marker X in column 72
+ */
+
+// -- Hover documentation -----------------------------------------------------
+
+/**
+ * Assembler directives with hover documentation.
+ * Keys match the uppercase mnemonic exactly.
+ */
+export const HLASM_DIRECTIVES: Record<string, string> = {
+  ACONTROL: '**ACONTROL** -- Sets assembler processing options inline in source.',
+  ADATA: '**ADATA** -- Writes an associated-data record to SYSADATA for use by debuggers and cross-referencers.',
+  AINSERT: '**AINSERT** -- Inserts a generated statement into the assembler input stream. Used inside macros to inject code dynamically.',
+  ALIAS: '**ALIAS** -- Assigns an alternate external name to a symbol, exported to the object deck for linker resolution.',
+  AMODE: '**AMODE** -- Addressing mode for the preceding CSECT/RSECT. Values: 24, 31, 64, or ANY.',
+  CATTR: '**CATTR** -- Class attribute (GOFF only). Associates code or data with a named program-object class.',
+  CCW: '**CCW** -- Channel Command Word (format 0). 8-byte I/O control block for EXCP channel programs. RMODE 24 only.',
+  CCW0: '**CCW0** -- Channel Command Word (format 0). 8-byte I/O control block for EXCP channel programs. RMODE 24 only.',
+  CCW1: '**CCW1** -- Channel Command Word (format 1). Like CCW0 but supports 31-bit data addresses.',
+  CEJECT: '**CEJECT** -- Conditional page-eject. Advances to a new listing page only if fewer than n lines remain.',
+  CNOP: '**CNOP** -- Inserts NOP instructions to align the location counter to a halfword, fullword, or doubleword boundary.',
+  COM: '**COM** -- Initiates or continues a blank common section.',
+  COPY: '**COPY** -- Copies source statements from a library member into the current assembly.',
+  CSECT: '**CSECT** -- Begins or continues an executable (relocatable) code section.',
+  CXD: '**CXD** -- Reserves a fullword the linker fills with the combined length of all external dummy sections.',
+  DC: '**DC** -- Define Constant. Allocates initialized storage. Type codes: C=char, X=hex, F=fullword, H=halfword, A=addr, D=double, P=packed, Z=zoned.',
+  DROP: '**DROP** -- Cancels a USING base-register designation.',
+  DS: '**DS** -- Define Storage. Reserves uninitialized storage. Same type/length syntax as DC.',
+  DSECT: '**DSECT** -- Dummy section. Describes storage layout without generating object code. Used to map control blocks.',
+  DXD: '**DXD** -- Declares an external dummy section whose aggregate length the linker resolves into a CXD slot.',
+  EJECT: '**EJECT** -- Forces a page-break in the assembler listing.',
+  END: '**END** -- Ends the assembly. Optionally specifies the entry-point address.',
+  ENTRY: '**ENTRY** -- Declares symbols in this module as externally visible entry points for the linker.',
+  EQU: '**EQU** -- Assigns a value and optional attributes to a symbol without allocating storage.',
+  EXITCTL: '**EXITCTL** -- Passes control information to a user-written assembler exit.',
+  EXTRN: '**EXTRN** -- Declares symbols defined in another module, generating external references for the linker.',
+  ICTL: '**ICTL** -- Overrides default statement-field boundaries. Must be the first non-comment statement.',
+  ISEQ: '**ISEQ** -- Enables source-record sequence checking within the specified identification columns.',
+  LOCTR: '**LOCTR** -- Redirects output to a named sub-section within the current control section.',
+  LTORG: '**LTORG** -- Emits all pending literals at the current location. If omitted, the pool is placed at END.',
+  MACRO: '**MACRO** -- Begins a macro definition. The next line is the prototype; MEND closes it.',
+  MEND: '**MEND** -- Ends a macro definition.',
+  MEXIT: '**MEXIT** -- Exits a macro expansion early.',
+  MHELP: '**MHELP** -- Controls macro debugging diagnostics via a binary option mask.',
+  MNOTE: '**MNOTE** -- Issues a user-defined severity message in the assembler listing. Severity >= 8 increments the return code.',
+  OPSYN: '**OPSYN** -- Creates an alias for an instruction, directive, or macro name.',
+  ORG: '**ORG** -- Sets the location counter to a specified address, optionally with alignment and offset.',
+  POP: '**POP** -- Restores PRINT or USING settings previously saved by PUSH.',
+  PRINT: '**PRINT** -- Controls assembler listing options: ON/OFF, GEN/NOGEN, DATA/NODATA.',
+  PUNCH: '**PUNCH** -- Writes a record directly to SYSPUNCH without assembling it.',
+  PUSH: '**PUSH** -- Saves the current PRINT or USING state for later restoration with POP.',
+  REPRO: '**REPRO** -- Copies the next source record verbatim to SYSPUNCH.',
+  RMODE: '**RMODE** -- Residence mode: 24=below 16 MB, 31=below 2 GB, ANY=linker decides.',
+  RSECT: '**RSECT** -- Read-only section. Verifies no self-modifying instructions are present. Use for LPA or common storage.',
+  SPACE: '**SPACE** -- Inserts blank lines in the assembler listing.',
+  START: '**START** -- Starts the first control section, optionally setting the initial location counter value.',
+  TITLE: '**TITLE** -- Sets the assembler listing page heading and optional 8-character deck ID.',
+  USING: '**USING** -- Establishes base-register addressability so the assembler can compute displacements automatically.',
+  WXTRN: '**WXTRN** -- Weak external. Like EXTRN but unresolved references are treated as zero instead of errors.',
+  XATTR: '**XATTR** -- Extended attribute (GOFF). Attaches linkage attributes to an external symbol.',
+};
+
+/**
+ * Conditional-assembly and macro instructions with hover documentation.
+ */
+export const HLASM_MACRO_INSTS: Record<string, string> = {
+  AIF: '**AIF**  --  Assembler IF. Conditional branch based on a logical expression evaluated at assembly time. Jumps to a sequence symbol if the condition is true. Part of conditional assembly; not a machine instruction.',
+  AIFB: '**AIFB**  --  Synonym of AIF. Identical behavior; supported for compatibility.',
+  AGO: '**AGO**  --  Assembler GO. Unconditional branch to a sequence symbol at assembly time. Used to skip over code sections during conditional assembly.',
+  ANOP: '**ANOP**  --  Assembler No-OPeration. Acts as a target for AGO/AIF branches (provides a sequence symbol) without generating any object code.',
+  ASPACE: '**ASPACE**  --  Assembler SPACE. Inserts blank lines in the listing during a macro expansion, equivalent to SPACE but valid inside macro bodies.',
+  AEJECT: '**AEJECT**  --  Assembler EJECT. Forces a listing page-break from within a macro expansion.',
+  ACTR: '**ACTR**  --  Assembler CounTeR. Sets the maximum number of AIF/AGO branches the assembler will follow in a single expansion. Prevents infinite loops. Default is 4096.',
+  AREAD: '**AREAD**  --  Assembler READ. Reads the next source record into a SETC variable at assembly time. Used for generative programming where input data drives code generation.',
+  GBLA: '**GBLA**  --  Global Arithmetic SET symbol declaration. Declares one or more `&name` variables as global arithmetic (integer) variables, shared across all macro invocations in the assembly.',
+  GBLB: '**GBLB**  --  Global Binary SET symbol declaration. Declares one or more `&name` variables as global binary (boolean, 0/1) variables.',
+  GBLC: '**GBLC**  --  Global Character SET symbol declaration. Declares one or more `&name` variables as global character-string variables.',
+  LCLA: '**LCLA**  --  Local Arithmetic SET symbol declaration. Declares local arithmetic variables, scoped to the current macro invocation.',
+  LCLB: '**LCLB**  --  Local Binary SET symbol declaration. Declares local boolean variables, scoped to the current macro invocation.',
+  LCLC: '**LCLC**  --  Local Character SET symbol declaration. Declares local character-string variables, scoped to the current macro invocation.',
+  SETA: '**SETA**  --  SET Arithmetic. Assigns an integer value to an arithmetic SET symbol. Supports arithmetic operators `+ - * /` and built-in functions like `FIND` and `INDEX`.',
+  SETAF: '**SETAF**  --  SET Arithmetic Func. Calls an external function module to compute the value assigned to an arithmetic SET symbol.',
+  SETB: '**SETB**  --  SET Binary. Assigns a boolean (0 or 1) value to a binary SET symbol. The operand is a logical expression: `(expression)` or a 0/1 literal.',
+  SETC: '**SETC**  --  SET Character. Assigns a character string to a character SET symbol. Supports concatenation, substring notation, and type-attribute queries.',
+  SETCF: '**SETCF**  --  SET Character Func. Calls an external function module to compute the character string assigned to a SETC symbol.',
+};
+
+/**
+ * Commonly used z/Architecture machine instruction mnemonics with hover documentation.
+ * Covers the instructions most frequently encountered in z/OS systems-programming assembler.
+ */
+export const HLASM_INSTRUCTIONS: Record<string, string> = {
+  // Load/Store
+  L:    '**L**  --  Load. Loads a 32-bit value from storage into a GPR. `L R1,D2(X2,B2)`',
+  LR:   '**LR**  --  Load Register. Copies the 32-bit content of one GPR to another. `LR R1,R2`',
+  LH:   '**LH**  --  Load Halfword. Sign-extends a 16-bit memory value into a 32-bit GPR.',
+  LHI:  '**LHI**  --  Load Halfword Immediate. Sign-extends a 16-bit immediate into a 32-bit GPR.',
+  LG:   '**LG**  --  Load (64-bit). Loads a 64-bit value from storage into a GPR.',
+  LGR:  '**LGR**  --  Load Register (64-bit). Copies the full 64-bit content of a GPR.',
+  LGF:  '**LGF**  --  Load Fullword -> 64-bit. Sign-extends a 32-bit memory value into a 64-bit GPR.',
+  LGFR: '**LGFR**  --  Load Fullword Register -> 64-bit. Sign-extends the lower 32 bits of a GPR into 64 bits.',
+  LGH:  '**LGH**  --  Load Halfword -> 64-bit. Sign-extends a 16-bit memory value into a 64-bit GPR.',
+  LGHI: '**LGHI**  --  Load Halfword Immediate -> 64-bit. Sign-extends a 16-bit immediate into 64 bits.',
+  LA:   '**LA**  --  Load Address. Computes an effective address `D2(X2,B2)` and loads it into a GPR. Does not access storage; the result is always 31-bit.',
+  LAY:  '**LAY**  --  Load Address (long displacement). Like LA but with a 20-bit signed displacement.',
+  LAG:  '**LAG**  --  Load Address 64-bit. Computes and loads a 64-bit effective address.',
+  LAM:  '**LAM**  --  Load Access Multiple. Loads a range of access registers from storage.',
+  LARL: '**LARL**  --  Load Address Relative Long. Loads the address of a label into a GPR using a PC-relative displacement (no base register needed).',
+  LAE:  '**LAE**  --  Load Address Extended. Loads both a GPR and an access register from a storage address.',
+  ST:   '**ST**  --  Store. Stores the low 32 bits of a GPR to storage.',
+  STG:  '**STG**  --  Store (64-bit). Stores all 64 bits of a GPR to storage.',
+  STH:  '**STH**  --  Store Halfword. Stores the low 16 bits of a GPR to storage.',
+  STC:  '**STC**  --  Store Character. Stores the low 8 bits of a GPR to storage.',
+  STCM: '**STCM**  --  Store Characters under Mask. Stores selected bytes of a GPR based on a 4-bit byte mask.',
+  STM:  '**STM**  --  Store Multiple. Stores a consecutive range of GPRs to storage (wraps at 15->0).',
+  STMG: '**STMG**  --  Store Multiple (64-bit). Stores full 64-bit GPR range to storage.',
+  LM:   '**LM**  --  Load Multiple. Loads a consecutive range of GPRs from storage.',
+  LMG:  '**LMG**  --  Load Multiple (64-bit). Loads full 64-bit GPR range from storage.',
+  LMH:  '**LMH**  --  Load Multiple High. Loads the high halves of a range of GPRs from storage.',
+  MVC:  '**MVC**  --  Move Character. Copies up to 256 bytes from one storage location to another. `MVC D1(L,B1),D2(B2)`. The copy proceeds left-to-right, byte by byte.',
+  MVCL: '**MVCL**  --  Move Character Long. Copies up to 16 MB; padding character can be specified. Operands in even-odd register pairs.',
+  MVCP: '**MVCP**  --  Move to Primary. Copies bytes from a secondary address space to the primary address space.',
+  MVCS: '**MVCS**  --  Move to Secondary. Copies bytes from the primary address space to a secondary address space.',
+  MVI:  '**MVI**  --  Move Immediate. Stores a 1-byte immediate value to storage.',
+  MVHHI: '**MVHHI**  --  Move Halfword Halfword Immediate. Stores a 16-bit immediate to a halfword in storage.',
+  MVHI: '**MVHI**  --  Move Halfword Immediate. Stores a sign-extended 16-bit immediate as a 32-bit fullword in storage.',
+  MVGHI: '**MVGHI**  --  Move Halfword Immediate (64-bit). Stores a sign-extended 16-bit immediate as a 64-bit doubleword in storage.',
+  ICM:  '**ICM**  --  Insert Characters under Mask. Loads selected bytes from storage into a GPR under a 4-bit byte mask. Sets the condition code based on the result.',
+  IC:   '**IC**  --  Insert Character. Inserts a single byte from storage into the low 8 bits of a GPR without clearing the other bytes.',
+  IIHH: '**IIHH / IIHL / IILH / IILL**  --  Insert Immediate (Half). Inserts a 16-bit immediate into a quarter of a 64-bit GPR without affecting the other 48 bits.',
+  IIHL: '**IIHL**  --  Insert Immediate High-Low. Inserts a 16-bit immediate into bits 16-31 of a 64-bit GPR.',
+  IILH: '**IILH**  --  Insert Immediate Low-High. Inserts a 16-bit immediate into bits 32-47 of a 64-bit GPR.',
+  IILL: '**IILL**  --  Insert Immediate Low-Low. Inserts a 16-bit immediate into the low 16 bits of a 64-bit GPR.',
+  // Arithmetic
+  A:    '**A**  --  Add (32-bit). Adds a fullword in storage to a GPR. Sets condition code.',
+  AR:   '**AR**  --  Add Register (32-bit). Adds two GPRs. Sets condition code.',
+  AH:   '**AH**  --  Add Halfword. Sign-extends a halfword from storage and adds to a GPR.',
+  AHI:  '**AHI**  --  Add Halfword Immediate. Adds a 16-bit signed immediate to a 32-bit GPR.',
+  AG:   '**AG**  --  Add (64-bit). Adds a doubleword in storage to a 64-bit GPR.',
+  AGR:  '**AGR**  --  Add Register (64-bit). Adds two 64-bit GPRs.',
+  AGFI: '**AGFI**  --  Add Fullword Immediate (64-bit). Adds a sign-extended 32-bit immediate to a 64-bit GPR.',
+  AGHI: '**AGHI**  --  Add Halfword Immediate (64-bit). Adds a 16-bit immediate to a 64-bit GPR.',
+  AGFR: '**AGFR**  --  Add Fullword Register (64-bit). Sign-extends the lower 32 bits of one GPR and adds to a 64-bit GPR.',
+  AL:   '**AL**  --  Add Logical (32-bit). Like A but treated as unsigned; no overflow exception.',
+  ALR:  '**ALR**  --  Add Logical Register (32-bit). Adds two GPRs as unsigned 32-bit values.',
+  ALG:  '**ALG**  --  Add Logical (64-bit). Adds a doubleword as unsigned 64-bit value.',
+  ALGR: '**ALGR**  --  Add Logical Register (64-bit). Unsigned 64-bit GPR add.',
+  ALGF: '**ALGF**  --  Add Logical Fullword (64-bit). Zero-extends a 32-bit memory value and adds to a 64-bit GPR.',
+  ALGFR: '**ALGFR**  --  Add Logical Fullword Register (64-bit). Zero-extends the lower 32 bits of one GPR and adds to a 64-bit GPR.',
+  ALHHLR: '**ALHHLR**  --  Add Logical High-High-Low Register. Adds the high halves of two GPRs.',
+  ALY:  '**ALY**  --  Add Logical (long displacement). Like AL with 20-bit displacement.',
+  S:    '**S**  --  Subtract (32-bit). Subtracts a fullword in storage from a GPR.',
+  SR:   '**SR**  --  Subtract Register (32-bit). Subtracts one GPR from another.',
+  SH:   '**SH**  --  Subtract Halfword. Sign-extends a halfword from storage and subtracts from a GPR.',
+  SHI:  '**SHI**  --  Subtract Halfword Immediate (synonym of AHI with negated immediate).',
+  SG:   '**SG**  --  Subtract (64-bit).',
+  SGR:  '**SGR**  --  Subtract Register (64-bit).',
+  SGFR: '**SGFR**  --  Subtract Fullword Register (64-bit). Sign-extends lower 32 bits and subtracts.',
+  SL:   '**SL**  --  Subtract Logical (32-bit). Unsigned subtract.',
+  SLR:  '**SLR**  --  Subtract Logical Register (32-bit). Unsigned subtract of two GPRs.',
+  SLG:  '**SLG**  --  Subtract Logical (64-bit).',
+  SLGR: '**SLGR**  --  Subtract Logical Register (64-bit).',
+  SLGFR: '**SLGFR**  --  Subtract Logical Fullword Register (64-bit).',
+  M:    '**M**  --  Multiply (32x64). Multiplies a 32-bit GPR by a fullword in storage; 64-bit result in even-odd pair.',
+  MR:   '**MR**  --  Multiply Register. Even-odd pair x GPR -> 64-bit result.',
+  MH:   '**MH**  --  Multiply Halfword. Multiplies a GPR by a halfword; 32-bit result (no overflow check).',
+  MHI:  '**MHI**  --  Multiply Halfword Immediate.',
+  MG:   '**MG**  --  Multiply (64-bit). 64x64 -> 128-bit in even-odd pair.',
+  MGR:  '**MGR**  --  Multiply Register (64-bit).',
+  MGHI: '**MGHI**  --  Multiply Halfword Immediate (64-bit).',
+  MS:   '**MS**  --  Multiply Single (32-bit). Multiplies two 32-bit values; 32-bit result (low half).',
+  MSR:  '**MSR**  --  Multiply Single Register.',
+  MSG:  '**MSG**  --  Multiply Single (64-bit). 64-bit x storage doubleword -> 64-bit result.',
+  MSGR: '**MSGR**  --  Multiply Single Register (64-bit).',
+  MSFI: '**MSFI**  --  Multiply Single Fullword Immediate.',
+  MSGFI: '**MSGFI**  --  Multiply Single Fullword Immediate (64-bit).',
+  D:    '**D**  --  Divide (64/32). Divides a 64-bit value in an even-odd GPR pair by a 32-bit storage operand.',
+  DR:   '**DR**  --  Divide Register.',
+  DL:   '**DL**  --  Divide Logical (unsigned) 64/32.',
+  DLR:  '**DLR**  --  Divide Logical Register.',
+  DLG:  '**DLG**  --  Divide Logical (128/64). Unsigned 128/64 -> quotient + remainder.',
+  DLGR: '**DLGR**  --  Divide Logical Register (64-bit).',
+  // Compare
+  C:    '**C**  --  Compare (32-bit). Compares a GPR to a fullword in storage; sets condition code. No result stored.',
+  CR:   '**CR**  --  Compare Register (32-bit). Compares two GPRs.',
+  CH:   '**CH**  --  Compare Halfword. Sign-extends a halfword from storage and compares.',
+  CHI:  '**CHI**  --  Compare Halfword Immediate. Compares a GPR to a 16-bit signed immediate.',
+  CG:   '**CG**  --  Compare (64-bit).',
+  CGR:  '**CGR**  --  Compare Register (64-bit).',
+  CGFI: '**CGFI**  --  Compare Fullword Immediate (64-bit).',
+  CGHI: '**CGHI**  --  Compare Halfword Immediate (64-bit).',
+  CGFR: '**CGFR**  --  Compare Fullword Register (64-bit).',
+  CL:   '**CL**  --  Compare Logical (32-bit). Unsigned comparison of a GPR to a fullword.',
+  CLR:  '**CLR**  --  Compare Logical Register (32-bit).',
+  CLG:  '**CLG**  --  Compare Logical (64-bit).',
+  CLGR: '**CLGR**  --  Compare Logical Register (64-bit).',
+  CLGFR: '**CLGFR**  --  Compare Logical Fullword Register (64-bit). Zero-extends lower 32 bits of one GPR.',
+  CLM:  '**CLM**  --  Compare Logical under Mask. Compares selected bytes of a GPR with storage bytes under a 4-bit mask.',
+  CLC:  '**CLC**  --  Compare Logical Character. Compares up to 256 bytes of storage.',
+  CLCL: '**CLCL**  --  Compare Logical Character Long. Compares up to 16 MB; padding character supported.',
+  CLI:  '**CLI**  --  Compare Logical Immediate. Compares a single byte in storage to an 8-bit immediate.',
+  CLFI: '**CLFI**  --  Compare Logical Fullword Immediate. Unsigned compare of a GPR to a 32-bit immediate.',
+  CLGFI: '**CLGFI**  --  Compare Logical Fullword Immediate (64-bit).',
+  CRT:  '**CRT**  --  Compare and Trap (Register, 32-bit). Compares two GPRs and traps (program interrupt) if the condition is true rather than branching. Eliminates a branch.',
+  CGRT: '**CGRT**  --  Compare and Trap Register (64-bit).',
+  // Branch
+  B:    '**B**  --  Branch (unconditional). Extended mnemonic for `BC 15,...`.',
+  BR:   '**BR**  --  Branch Register (unconditional). Extended mnemonic for `BCR 15,R`.',
+  BC:   '**BC**  --  Branch on Condition. Branches to an address if the condition code matches the mask. `BC 8,...` = branch if equal.',
+  BCR:  '**BCR**  --  Branch on Condition Register. Branches to the address in a GPR if condition code matches mask. `BCR 15,R14` = branch to R14 unconditionally (i.e. return).',
+  BCTR: '**BCTR**  --  Branch on CounT Register. Decrements a GPR and branches if not zero (32-bit counter). The branch target is in another GPR. `BCTR R,0` = no branch, just decrement.',
+  BCTG: '**BCTG**  --  Branch on CounT (64-bit). Decrements a 64-bit GPR and branches if not zero.',
+  BXH:  '**BXH**  --  Branch on indeX High. Adds an increment (odd GPR) to an index (GPR), then branches if the result is greater than the comparand (even GPR).',
+  BXHG: '**BXHG**  --  Branch on indeX High (64-bit).',
+  BXLE: '**BXLE**  --  Branch on indeX Low or Equal. Like BXH but branches when result <= comparand.',
+  BXLEG: '**BXLEG**  --  Branch on indeX Low or Equal (64-bit).',
+  BE:   '**BE**  --  Branch if Equal. Extended mnemonic for `BC 8,...`. CC = 0.',
+  BNE:  '**BNE**  --  Branch if Not Equal. Extended mnemonic for `BC 7,...`.',
+  BH:   '**BH**  --  Branch if High. Extended mnemonic for `BC 2,...`. CC = 2.',
+  BNH:  '**BNH**  --  Branch if Not High. Extended mnemonic for `BC 13,...`.',
+  BL:   '**BL**  --  Branch if Low. Extended mnemonic for `BC 4,...`. CC = 1.',
+  BNL:  '**BNL**  --  Branch if Not Low. Extended mnemonic for `BC 11,...`.',
+  BZ:   '**BZ**  --  Branch if Zero. Extended mnemonic for `BC 8,...`. Synonym of BE for condition-code contexts.',
+  BNZ:  '**BNZ**  --  Branch if Not Zero. Extended mnemonic for `BC 7,...`.',
+  BO:   '**BO**  --  Branch if Overflow. Extended mnemonic for `BC 1,...`. CC = 3.',
+  BNO:  '**BNO**  --  Branch if No Overflow. Extended mnemonic for `BC 14,...`.',
+  BRC:  '**BRC**  --  Branch Relative on Condition. PC-relative branch with immediate displacement; no base register needed.',
+  BRCL: '**BRCL**  --  Branch Relative on Condition Long. PC-relative branch with 32-bit displacement.',
+  JAS:  '**JAS**  --  Jump And Save (extended mnemonic). PC-relative branch-and-link using BRAS.',
+  BRAS: '**BRAS**  --  Branch Relative And Save. Saves the return address (PC+1) in a GPR and branches via PC-relative displacement. Commonly used to establish addressability: `BRAS R12,*+4` then `USING *-4,R12`.',
+  BRASL: '**BRASL**  --  Branch Relative And Save Long. Like BRAS with a 32-bit displacement.',
+  BASR: '**BASR**  --  Branch And Save Register. Saves the return address in R1 and branches to the address in R2. `BASR R12,0` saves the current PC into R12 and falls through (base register setup).',
+  BAS:  '**BAS**  --  Branch And Save. Like BASR but the target is a storage address.',
+  BASSM: '**BASSM**  --  Branch And Save and Set Mode. Saves the return address + current AMODE in R1, then loads a new AMODE from the target address and branches. Used for AMODE switching.',
+  BSM:  '**BSM**  --  Branch and Set Mode. Branches and changes AMODE; does not save the return address.',
+  BAKR: '**BAKR**  --  Branch And Keep Registers. Saves the current register state on the linkage stack and branches. The pair with PR (Program Return). Used by authorized code for safe call/return.',
+  PR:   '**PR**  --  Program Return. Restores registers from the linkage stack and returns from a BAKR call.',
+  // Bitwise / logical
+  N:    '**N**  --  AND (32-bit). Bitwise AND of a GPR with a fullword in storage.',
+  NR:   '**NR**  --  AND Register (32-bit). Bitwise AND of two GPRs.',
+  NG:   '**NG**  --  AND (64-bit). Bitwise AND of a 64-bit GPR with a doubleword in storage.',
+  NGR:  '**NGR**  --  AND Register (64-bit).',
+  NI:   '**NI**  --  AND Immediate. Bitwise AND of a storage byte with an 8-bit immediate.',
+  NC:   '**NC**  --  AND Character. Bitwise AND of two storage fields (up to 256 bytes).',
+  NIHH: '**NIHH**  --  AND Immediate High-High. ANDs bits 0-15 of a 64-bit GPR with a 16-bit immediate.',
+  NIHL: '**NIHL**  --  AND Immediate High-Low. ANDs bits 16-31.',
+  NILH: '**NILH**  --  AND Immediate Low-High. ANDs bits 32-47.',
+  NILL: '**NILL**  --  AND Immediate Low-Low. ANDs the low 16 bits.',
+  O:    '**O**  --  OR (32-bit). Bitwise OR of a GPR with a fullword.',
+  OR:   '**OR**  --  OR Register (32-bit).',
+  OG:   '**OG**  --  OR (64-bit).',
+  OGR:  '**OGR**  --  OR Register (64-bit).',
+  OI:   '**OI**  --  OR Immediate. Bitwise OR of a storage byte with an 8-bit immediate.',
+  OC:   '**OC**  --  OR Character. Bitwise OR of two storage fields.',
+  OIHH: '**OIHH**  --  OR Immediate High-High.',
+  OIHL: '**OIHL**  --  OR Immediate High-Low.',
+  OILH: '**OILH**  --  OR Immediate Low-High.',
+  OILL: '**OILL**  --  OR Immediate Low-Low.',
+  X:    '**X**  --  XOR (32-bit). Exclusive-OR of a GPR with a fullword.',
+  XR:   '**XR**  --  XOR Register (32-bit). `XR R,R` sets R to zero efficiently.',
+  XG:   '**XG**  --  XOR (64-bit).',
+  XGR:  '**XGR**  --  XOR Register (64-bit). `XGR R,R` zeroes the 64-bit GPR.',
+  XI:   '**XI**  --  XOR Immediate. Exclusive-OR of a storage byte with an 8-bit immediate.',
+  XC:   '**XC**  --  XOR Character. Exclusive-OR of two storage fields. `XC AREA(len),AREA` zeroes the area.',
+  // Shift
+  SRL:  '**SRL**  --  Shift Right Logical (32-bit). Shifts low 32 bits right by 0-63 positions, filling with zeros.',
+  SRLG: '**SRLG**  --  Shift Right Logical (64-bit).',
+  SLL:  '**SLL**  --  Shift Left Logical (32-bit).',
+  SLLG: '**SLLG**  --  Shift Left Logical (64-bit).',
+  SRA:  '**SRA**  --  Shift Right Arithmetic (32-bit). Sign-extending right shift.',
+  SRAG: '**SRAG**  --  Shift Right Arithmetic (64-bit).',
+  SLA:  '**SLA**  --  Shift Left Arithmetic (32-bit). Sets overflow if sign bit changes.',
+  SLAG: '**SLAG**  --  Shift Left Arithmetic (64-bit).',
+  SRDL: '**SRDL**  --  Shift Right Double Logical. Right-shifts an even-odd GPR pair as a 64-bit value.',
+  SLDA: '**SLDA**  --  Shift Left Double Arithmetic.',
+  SRDA: '**SRDA**  --  Shift Right Double Arithmetic.',
+  SLDL: '**SLDL**  --  Shift Left Double Logical.',
+  // Translate / convert
+  TR:   '**TR**  --  TRanslate. Replaces each byte of a field with the byte at the corresponding offset in a 256-byte translate table. Used for EBCDIC<->ASCII conversion and character classification.',
+  TRT:  '**TRT**  --  TRanslate and Test. Scans a field, translates each byte via a table; stops when a nonzero table entry is found. Returns the address and value of the stop byte.',
+  TRTE: '**TRTE**  --  Translate and Test Extended. Like TRT but handles 1-byte, 2-byte, and 4-byte table entries.',
+  TRTR: '**TRTR**  --  Translate and Test Reverse. Like TRT but scans right-to-left.',
+  TROT: '**TROT**  --  Translate One to Two. Converts a single-byte source string to a two-byte-per-character destination using a table.',
+  TROO: '**TROO**  --  Translate One to One. Single-byte source and destination, extended function codes.',
+  TRTO: '**TRTO**  --  Translate Two to One. Two-byte source mapped to one-byte destination.',
+  TRTT: '**TRTT**  --  Translate Two to Two. Two-byte source mapped to two-byte destination.',
+  PACK: '**PACK**  --  Converts zoned-decimal digits (one per byte) to packed-decimal format (two digits per byte). The sign nibble is placed in the low half of the last byte.',
+  UNPK: '**UNPK**  --  Converts packed-decimal digits to zoned-decimal format.',
+  CVB:  '**CVB**  --  Convert to Binary. Converts a packed-decimal doubleword in storage to a 32-bit binary integer in a GPR.',
+  CVD:  '**CVD**  --  Convert to Decimal. Converts a 32-bit binary integer to a packed-decimal doubleword and stores it.',
+  CVBG: '**CVBG**  --  Convert to Binary (64-bit). Converts a packed quadword to a 64-bit GPR.',
+  CVDG: '**CVDG**  --  Convert to Decimal (64-bit). Converts to packed quadword.',
+  // Decimal arithmetic
+  AP:   '**AP**  --  Add Packed. Adds two packed-decimal fields in storage.',
+  SP:   '**SP**  --  Subtract Packed.',
+  MP:   '**MP**  --  Multiply Packed.',
+  DP:   '**DP**  --  Divide Packed.',
+  CP:   '**CP**  --  Compare Packed.',
+  ZAP:  '**ZAP**  --  Zero and Add Packed. Zeroes the destination then adds the source packed-decimal field.',
+  SRP:  '**SRP**  --  Shift and Round Packed. Shifts a packed-decimal field left or right by a specified number of digit positions with optional rounding.',
+  ED:   '**ED**  --  EDit. Formats a packed-decimal field into a printable character string using an edit pattern.',
+  EDMK: '**EDMK**  --  EDit and MarK. Like ED but also stores the address of the first significant digit into R1.',
+  // String / search
+  SRST: '**SRST**  --  Search String. Scans a string for a specified delimiter byte (in R0). Returns address of the delimiter or the end of the string.',
+  SRSTU: '**SRSTU**  --  Search String Unicode. Like SRST for UTF-16 strings.',
+  MVST: '**MVST**  --  Move String. Copies a string up to and including a specified delimiter byte (in R0).',
+  CLST: '**CLST**  --  Compare Logical String. Compares two null-terminated strings byte-by-byte.',
+  // Test
+  TM:   '**TM**  --  Test under Mask. ANDs a storage byte with an 8-bit immediate mask; sets the condition code based on whether selected bits are all 0, mixed, or all 1.',
+  TMY:  '**TMY**  --  Test under Mask (long displacement). Like TM with a 20-bit signed displacement.',
+  TMHH: '**TMHH**  --  Test under Mask High-High. Tests bits 0-15 of a 64-bit GPR.',
+  TMHL: '**TMHL**  --  Test under Mask High-Low. Tests bits 16-31.',
+  TMLH: '**TMLH**  --  Test under Mask Low-High. Tests bits 32-47.',
+  TMLL: '**TMLL**  --  Test under Mask Low-Low. Tests bits 48-63.',
+  // Synchronization / atomics
+  CS:   '**CS**  --  Compare and Swap (32-bit). Atomic: if storage = R1, swap storage <-> R3, CC=0; else load storage into R1, CC=1. Used to implement lock-free data structures.',
+  CSG:  '**CSG**  --  Compare and Swap (64-bit).',
+  CDS:  '**CDS**  --  Compare Double and Swap (2x32-bit). Atomic compare-and-swap on a 64-bit aligned even-odd pair.',
+  CDSG: '**CDSG**  --  Compare Double and Swap (2x64-bit). Atomic 128-bit compare-and-swap.',
+  // Privileged / system
+  SPKA: '**SPKA**  --  Set PSW Key from Address. Loads a new storage protection key from the low bits of a GPR. Requires supervisor state.',
+  MODESET: '**MODESET**  --  IBM macro (not a machine instruction). Switches CPU state between problem state and supervisor state. Common in SVC and authorized assembler routines.',
+  SVC:  '**SVC**  --  SuperVisor Call. Generates a supervisor-call interrupt with the given interrupt code (0-255). Used to invoke z/OS services.',
+  STIMER: '**STIMER**  --  IBM macro. Causes the task to wait for a specified interval or until a timer event.',
+  ESTAEX: '**ESTAEX**  --  IBM macro. Establishes an Extended STAE (recovery) exit routine that is called when the task encounters an error.',
+  WTO:  '**WTO**  --  Write To Operator (IBM macro). Issues a multi-line or single-line message to the system console and optionally to the job log.',
+  ABEND: '**ABEND**  --  ABnormal END (IBM macro). Terminates the current task/job step abnormally with a user abend code. Can request a system dump.',
+  ATTACH: '**ATTACH**  --  IBM macro. Creates a new z/OS task (subtask) and attaches it to the current task.',
+  SDUMPX: '**SDUMPX**  --  IBM macro. Requests a supervisor dump (system dump) of the specified address space(s) and/or storage areas.',
+  ALESERV: '**ALESERV**  --  IBM macro. Services the Access List Entry (ALE) for cross-memory addressing in AR mode.',
+  // Miscellaneous
+  NOP:  '**NOP**  --  No OPeration. Extended mnemonic for `BC 0,...`. Does nothing; used for alignment or patch space.',
+  NOPR: '**NOPR**  --  No OPeration Register. Extended mnemonic for `BCR 0,R`. Two-byte no-op.',
+  EX:   "**EX**  --  EXecute. Executes a single instruction at the target address with its second byte OR'd with the low byte of the executing GPR. Used to vary operand lengths at runtime.",
+  EXRL: '**EXRL**  --  EXecute Relative Long. Like EX but the target is specified by a PC-relative displacement.',
+  LNR:  '**LNR**  --  Load Negative Register. Loads the negated absolute value of a 32-bit GPR.',
+  LNGR: '**LNGR**  --  Load Negative Register (64-bit).',
+  LPR:  '**LPR**  --  Load Positive Register. Loads the absolute value of a 32-bit GPR.',
+  LPGR: '**LPGR**  --  Load Positive Register (64-bit).',
+  LCR:  '**LCR**  --  Load Complement Register. Loads the two\'s complement (negation) of a 32-bit GPR.',
+  LCGR: '**LCGR**  --  Load Complement Register (64-bit).',
+  STCK: '**STCK**  --  Store Clock. Stores the 64-bit TOD clock value to a doubleword in storage. Used for timing and unique-ID generation.',
+  STCKF: '**STCKF**  --  Store Clock Fast. Like STCK but uses the faster "fast" TOD format.',
+  STCKE: '**STCKE**  --  Store Clock Extended. Stores a 128-bit extended TOD clock value.',
+};
+
+// -- Tokenizer ----------------------------------------------------------------
+
+/**
+ * HLASM Monarch tokenizer.
+ *
+ * Fixed-column layout (standard HLASM source):
+ *   Col  1    : * = full-line comment
+ *   Col  1-8  : Name field (label)
+ *   Col  10-14: Operation (mnemonic)
+ *   Col  16+  : Operands
+ *   Col  72   : Continuation indicator (X)
+ *   Col  73-80: Sequence / ID field (ignored by assembler, not colorized)
+ *
+ * However, many HLASM sources (including these examples) use 2-space indentation
+ * rather than strict column alignment. The tokenizer handles both conventions.
+ */
+export const HLASM_HILITE = {
+  defaultToken: '',
+  ignoreCase: false,
+
+  // Keyword sets used in the tokenizer
+  directives: [
+    'ACONTROL','ADATA','AINSERT','ALIAS','AMODE',
+    'CATTR','CCW','CCW0','CCW1','CEJECT','CNOP',
+    'COM','COPY','CSECT','CXD',
+    'DC','DROP','DS','DSECT','DXD',
+    'EJECT','END','ENTRY','EQU','EXITCTL','EXTRN',
+    'ICTL','ISEQ','LOCTR','LTORG',
+    'MACRO','MEND','MEXIT','MHELP','MNOTE',
+    'OPSYN','ORG','POP','PRINT','PUNCH','PUSH',
+    'REPRO','RMODE','RSECT','SPACE','START','TITLE',
+    'USING','WXTRN','XATTR',
+  ],
+
+  macroInsts: [
+    'ACTR','AEJECT','AIF','AIFB','AGO','ANOP','AREAD','ASPACE',
+    'GBLA','GBLB','GBLC',
+    'LCLA','LCLB','LCLC',
+    'SETA','SETAF','SETB','SETC','SETCF',
+  ],
+
   tokenizer: {
     root: [
-      [/^\*.*$/, { token: 'comment', next: '@popall' }],
-      [/^[\w&#$@]+\s+/, { token: 'type', next: '@operator' }],
-      [/^[\s]{9}/, { token: 'default', next: '@operator' }],
-      [/^[\s]{15}/, { token: 'default', next: '@operands' }]
-    ],
-    operator: [
-      [/[\w&#$@]+\s*$/, { token: 'keyword', next: '@popall' }],
-      [/[\w&#$@]+\s+/, { token: 'keyword', next: '@operands' }]
-    ],
-    operands: [
-      [/\'[^\']+\'\s*$/, { token: 'string', next: '@popall' }],
-      [/\s*$/, { token: 'default', next: '@popall' }],
-      [/,\s*$/, { token: 'default', next: '@popall' }],
-      [/[\(\)\w&#$@]+\s*$/, { token: 'default', next: '@popall' }],
-      [/,[\(\)\w&#$@]+\s*$/, { token: 'default', next: '@popall' }],
-      [/,\s+[^X]*$/, { token: 'comment', next: '@popall' }],
-      [/\s+[\(\)\s\w&#$@]+\s*$/, { token: 'comment', next: '@popall' }],
+      // ---- Full-line comment: * in column 1 ----
+      [/^\*.*$/, 'hlasm-comment'],
 
-      [/,/, { token: 'default', next: '@cont' }],
-      [/[kldtn]'[\(\)\w&#$]+/, { token: 'number', next: '@cont' }],
-      [/'[^']+'/, { token: 'string', next: '@cont' }],
-      [/[\w&#$@]+=/, { token: 'variable.name', next: '@value' }]
+      // ---- Label in name field (cols 1-8), then transition to mnemonic ----
+      [/^([A-Z$#@][A-Z0-9$#@]*)(\s+)/, ['hlasm-label', '']],
+
+      // ---- No label  --  line starts with whitespace ----
+      [/^\s+/, ''],
+
+      // Fall through into mnemonic recognition
+      { include: '@mnemonic' },
     ],
-    cont: [
-      [/\s*[X]$/, { token: 'keyword', next: '@pop' }],
-      [/\s+[\s\.\/\(\)\w&#$@]+$/, { token: 'comment', next: '@popall' }],
-      [/\)\s*$/, { token: 'default', next: '@popall' }],
-      [/\(/, { token: 'default', next: '@operands' }],
-      [/\)/, { token: 'default', next: '@operands' }],
-      [/'[^\']+\'\s*/, { token: 'string', next: '@cont' }],
-      [/[kldtn]\'[\(\)\w&#$@]+/, { token: 'number', next: '@cont' }],
-      [/[\w&#$@]+=/, { token: 'variable.name', next: '@value' }],
-      [/[\.\/\(\)\w&#$@]+$/, { token: 'default', next: '@popall' }],
-      [/[\.\/\(\)\w&#$@]+/, { token: 'default', next: '@operands' }]
+
+    mnemonic: [
+      // Assembler directives
+      [/\b(ACONTROL|ADATA|AINSERT|ALIAS|AMODE|CATTR|CCW0?1?|CEJECT|CNOP|COM|COPY|CSECT|CXD|DC|DROP|DS|DSECT|DXD|EJECT|END|ENTRY|EQU|EXITCTL|EXTRN|ICTL|ISEQ|LOCTR|LTORG|MACRO|MEND|MEXIT|MHELP|MNOTE|OPSYN|ORG|POP|PRINT|PUNCH|PUSH|REPRO|RMODE|RSECT|SPACE|START|TITLE|USING|WXTRN|XATTR)\b/,
+        { token: 'hlasm-directive', next: '@operandLine' }],
+
+      // Macro/conditional-assembly instructions
+      [/\b(ACTR|AEJECT|AIFB?|AGO|ANOP|AREAD|ASPACE|GBLA|GBLB|GBLC|LCLA|LCLB|LCLC|SETA[FC]?|SETB|SETC[F]?)\b/,
+        { token: 'hlasm-macro-inst', next: '@operandLine' }],
+
+      // Machine instructions (broad set)
+      [/\b(ABEND|ADBR?|AEBR?|ADB?|AEB?|AFI|AGFR?|AGHI|AGFI|AGR?|AG|AGSI|AH[IY]?|ALHHLR|ALG[FR]?|ALR?|ALY|APR?|AR?|AXBR?|BAKR|BAS[RL]?M?|BASR?|BCR?|BCT[RG]|BRAS[L]?|BRC[L]?|BXHG?|BXLEG?|B[EHLNOPRZ][ELNOPRZ]?R?|CBR?|CDBR?|CDSG?|CDSTR?|CDS|CEBR?|CEQ?|CFC|CFI|CG[FHIR]?|CGDT?R?|CGIT?|CGRT?|CGS?R?|CHI?|CHHSI|CHRL|CHSI|CIH|CIT|CLCL[U]?|CLC[LE]?|CLF[I]?|CLG[EFIR]?|CLGT|CLGTR?|CLHF|CLHHR|CLHHS|CLHHU|CLHL[R]?|CLI[Y]?|CLIH|CLIY|CLJNL?[EHLOPRZ]|CLMH?|CLR[LT]?|CLRJ|CLT|CLTJ|CLY|CMH?|CMDP?F?R?|CNOP|CPX|CR[JT]?|CRB|CRJ|CS[GY]?|CSGR?|CSST|CSX|CXBR?|CXFBR?|CDB|CGRT|CLGRT|SLLG|SLLK|DDBR?|DEBR?|DIDBR?|DIEBR?|DL[GR]?|DR?|DSGFR?|DSGR?|DSST|DXR|EDBR?|EEXTR?|ESXTR?|EX[RL]?|FLOGR|IEDTR?|IEXTR?|IC[MY]?|IIHF|IIHH|IIHL|IILF|IILH|IILL|IPTE|KDB[ER]?|KDTR?|KXBR?|KXTR?|LA[EGMY]?|LAA[LG]?|LAAG?|LACG?|LAE|LAM[H]?|LAOG?|LARL|LAXG?|LBEAR|LBR?|LCG[FR]?|LCGR|LCR?|LDE[BR]?|LDETR?|LDGR?|LDR?|LDXBR?|LDXTR?|LEDTR?|LFAS|LFHAT|LG[ABCDEFHIMRSTVX]?|LGD[TR]?|LGF[IR]?|LGFRL|LGHI|LGH[RL]?|LGII?|LGMH|LGR?|LGRP|LGSW?|LH[ILRY]?|LHHR|LHRL|LHY|LKPAI?|LLB[HLR]?|LLC[HLR]?|LLD[HLR]?|LLESG?|LLGC[HR]?|LLGF[HR]?|LLGFRL|LLGHR?|LLGTR?|LLH[HR]?|LLHRL|LLIHF|LLIHH|LLIHL|LLILF|LLILH|LLILL|LLZRGF|LM[GH]?|LMD|LNDFR?|LNG[FR]?|LNGR|LNR?|LNXBR|LPDFR?|LPG[FR]?|LPGR|LPR?|LPXBR|LR[DFGV]?|LRL|LRV[GH]?|LRVGR?|LT[GY]?|LTDBR?|LTEBR?|LTGFR?|LTGR?|LTGF?|LTR?|LTXBR?|LTXTR?|LXDBR?|LXDTR?|LXEBR?|LXETR?|LXLBR|LXSBR|M[ACG]?|MA[CDY]?|MC|MDB[IR]?|MDTR?|MEEBR?|MH[IY]?|MLG?R?|MOD[FI]?|MP|MSG[FIR]?|MS[DFIYRP]?|MVC[DKL]?|MVCP?S?|MVGHI|MVI[Y]?|MVN|MVO|MVS|MVZ|NIAI|NC|NI[Y]?|NGR?|NIHF|NIHH|NIHL|NILF|NILH|NILL|NOP[R]?|NR?|OC|OI[Y]?|OGR?|OIHF|OIHH|OIHL|OILF|OILH|OILL|OR?|PACK|PCC|PCKMO|PFD[RL]?|PFPO|PKA|PKU|PLO|POP|PR|PRNO|PTER?|QPACI?|RLL[G]?|RNSBG|ROSBG|RISBGN?|RISBHG|RISBLG|RXSBG|S[ALG]?|SAC|SACF|SCOND|SDB[IR]?|SDTR?|SEBR?|SGRK?|SFASR|SFPC|SHI?|SLAK?|SLBGR?|SLBR?|SLB|SLDA|SLDL|SLGFR?|SLGRK?|SLGR?|SLG[SY]?|SLLG|SLLK|SLL[KY]?|SLR[GK]?|SLRK|SLY?|SQDBR?|SQDR?|SQEBR?|SQXBR?|SRA[GK]?|SRAG?|SRDA|SRDL|SRLG|SRLK?|SRST[U]?|SRLU|SSAIR?|SSK|SSM|ST[ACKM]?|STCM[HY]?|STC[KY]?|STFLE?|STFPC|STG|STH[RL]?|STMG?[H]?|STRV[GH]?|SVC|SXR|SXTR?|SY?|TM[HY]?|TMHH|TMHL|TMLH|TMLL|TP|TPI|TR[?]?|TRE|TROO|TROOT|TROT|TRTE?[SU]?|TRTR?[EU]?|TRTT|TS|UNPK[U]?|VA[B]?|VC[EFK]?|VN[M]?|VSTR?|VX[E]?|WFC|WTC|XI[Y]?|XGR?|XC|XR?|ZAP|CLST|CVBG?|CVDG?|EX[RL]?|LM[GH]?|MVN|MVZ|TR|TRT[E]?[SU]?|BAKR|PR|BXHG?|BXLEG?)\b/,
+        { token: 'hlasm-keyword', next: '@operandLine' }],
+
+      { include: '@operandRest' },
     ],
-    comment: [
-      [/.*$/, { token: 'comment', next: '@popall' }]
+
+    operandLine: [
+      // End-of-line remark (after operands, separated by at least one space)
+      [/\s{2,}.*$/, 'hlasm-comment'],
+
+      // Continuation indicator X in column 72 (end of line)
+      [/X$/, 'hlasm-cont'],
+
+      { include: '@operandRest' },
     ],
-    value: [
-      [/[\-\.\/\(\)\w&#$@]+$/, { token: 'default', next: '@popall' }],
-      [/'[^']+'\s*/, { token: 'string', next: '@operands' }],
-      [/[kldtn]\'[\(\)\w&#$@]+/, { token: 'number', next: '@operands' }],
-      [/[\-\.\/\(\)\w&#$@]+/, { token: 'default', next: '@operands' }]
-    ]
+
+    operandRest: [
+      // Variable symbol (&name)
+      [/&[A-Z#@$][A-Z0-9#@$_]*(\([^)]*\))?/, 'hlasm-variable'],
+
+      // Sequence symbol (.name)
+      [/\.[A-Z#@$][A-Z0-9#@$]*/, 'hlasm-seq'],
+
+      // Register references: R0-R15, with parentheses context
+      [/\b(R(?:1[0-5]|[0-9]))\b/, 'hlasm-register'],
+
+      // Hex, binary, character, and duplication literals: X'...' B'...' C'...' etc.
+      [/[0-9]*[ABCDEFGHKLPQSUVXYZ]'[^']*'/, 'hlasm-number'],
+
+      // Self-defining terms and numeric literals
+      [/[0-9]+/, 'hlasm-number'],
+
+      // String literals in apostrophes
+      [/'[^']*'/, 'hlasm-string'],
+
+      // Operators and delimiters
+      [/[=,().*+\-\/]/, 'hlasm-operator'],
+
+      // Ordinary symbols and keywords (plain identifier)
+      [/[A-Z$#@][A-Z0-9$#@_]*/, ''],
+    ],
   }
 };

--- a/webClient/src/app/editor/code-editor/monaco/hiliters/hlasm.ts
+++ b/webClient/src/app/editor/code-editor/monaco/hiliters/hlasm.ts
@@ -422,30 +422,34 @@ export const HLASM_HILITE = {
       // ---- Full-line comment: * in column 1 ----
       [/^\*.*$/, 'hlasm-comment'],
 
-      // ---- Label in name field (cols 1-8), then transition to mnemonic ----
-      [/^([A-Z$#@][A-Z0-9$#@]*)(\s+)/, ['hlasm-label', '']],
+      // ---- Label (identifier at col 1) + whitespace -> emit label, go to opcode state ----
+      [/^([A-Z$#@][A-Z0-9$#_@]*)(\s+)/, ['hlasm-label', { token: '', next: '@opcode' }]],
 
-      // ---- No label  --  line starts with whitespace ----
-      [/^\s+/, ''],
+      // ---- Label at end of line (no mnemonic follows) ----
+      [/^[A-Z$#@][A-Z0-9$#_@]*\s*$/, 'hlasm-label'],
 
-      // Fall through into mnemonic recognition
-      { include: '@mnemonic' },
+      // ---- No label: line starts with whitespace -> skip it, go to opcode state ----
+      [/^\s+/, { token: '', next: '@opcode' }],
     ],
 
-    mnemonic: [
+    // opcode state: we are positioned at the start of the operation field.
+    // All identifiers here are operation codes. Known directives and macro-assembly
+    // instructions get their specific tokens; everything else (machine instructions,
+    // user macros, unknown ops) falls through to hlasm-keyword for consistent coloring.
+    opcode: [
       // Assembler directives
-      [/\b(ACONTROL|ADATA|AINSERT|ALIAS|AMODE|CATTR|CCW0?1?|CEJECT|CNOP|COM|COPY|CSECT|CXD|DC|DROP|DS|DSECT|DXD|EJECT|END|ENTRY|EQU|EXITCTL|EXTRN|ICTL|ISEQ|LOCTR|LTORG|MACRO|MEND|MEXIT|MHELP|MNOTE|OPSYN|ORG|POP|PRINT|PUNCH|PUSH|REPRO|RMODE|RSECT|SPACE|START|TITLE|USING|WXTRN|XATTR)\b/,
+      [/(?:ACONTROL|ADATA|AINSERT|ALIAS|AMODE|CATTR|CCW[01]?|CEJECT|CNOP|COM|COPY|CSECT|CXD|DC|DROP|DS|DSECT|DXD|EJECT|END|ENTRY|EQU|EXITCTL|EXTRN|ICTL|ISEQ|LOCTR|LTORG|MACRO|MEND|MEXIT|MHELP|MNOTE|OPSYN|ORG|POP|PRINT|PUNCH|PUSH|REPRO|RMODE|RSECT|SPACE|START|TITLE|USING|WXTRN|XATTR)(?!\w)/,
         { token: 'hlasm-directive', next: '@operandLine' }],
 
-      // Macro/conditional-assembly instructions
-      [/\b(ACTR|AEJECT|AIFB?|AGO|ANOP|AREAD|ASPACE|GBLA|GBLB|GBLC|LCLA|LCLB|LCLC|SETA[FC]?|SETB|SETC[F]?)\b/,
+      // Macro / conditional-assembly instructions
+      [/(?:ACTR|AEJECT|AIFB?|AGO|ANOP|AREAD|ASPACE|GBLA|GBLB|GBLC|LCLA|LCLB|LCLC|SETAF?|SETB|SETCF?)(?!\w)/,
         { token: 'hlasm-macro-inst', next: '@operandLine' }],
 
-      // Machine instructions (broad set)
-      [/\b(ABEND|ADBR?|AEBR?|ADB?|AEB?|AFI|AGFR?|AGHI|AGFI|AGR?|AG|AGSI|AH[IY]?|ALHHLR|ALG[FR]?|ALR?|ALY|APR?|AR?|AXBR?|BAKR|BAS[RL]?M?|BASR?|BCR?|BCT[RG]|BRAS[L]?|BRC[L]?|BXHG?|BXLEG?|B[EHLNOPRZ][ELNOPRZ]?R?|CBR?|CDBR?|CDSG?|CDSTR?|CDS|CEBR?|CEQ?|CFC|CFI|CG[FHIR]?|CGDT?R?|CGIT?|CGRT?|CGS?R?|CHI?|CHHSI|CHRL|CHSI|CIH|CIT|CLCL[U]?|CLC[LE]?|CLF[I]?|CLG[EFIR]?|CLGT|CLGTR?|CLHF|CLHHR|CLHHS|CLHHU|CLHL[R]?|CLI[Y]?|CLIH|CLIY|CLJNL?[EHLOPRZ]|CLMH?|CLR[LT]?|CLRJ|CLT|CLTJ|CLY|CMH?|CMDP?F?R?|CNOP|CPX|CR[JT]?|CRB|CRJ|CS[GY]?|CSGR?|CSST|CSX|CXBR?|CXFBR?|CDB|CGRT|CLGRT|SLLG|SLLK|DDBR?|DEBR?|DIDBR?|DIEBR?|DL[GR]?|DR?|DSGFR?|DSGR?|DSST|DXR|EDBR?|EEXTR?|ESXTR?|EX[RL]?|FLOGR|IEDTR?|IEXTR?|IC[MY]?|IIHF|IIHH|IIHL|IILF|IILH|IILL|IPTE|KDB[ER]?|KDTR?|KXBR?|KXTR?|LA[EGMY]?|LAA[LG]?|LAAG?|LACG?|LAE|LAM[H]?|LAOG?|LARL|LAXG?|LBEAR|LBR?|LCG[FR]?|LCGR|LCR?|LDE[BR]?|LDETR?|LDGR?|LDR?|LDXBR?|LDXTR?|LEDTR?|LFAS|LFHAT|LG[ABCDEFHIMRSTVX]?|LGD[TR]?|LGF[IR]?|LGFRL|LGHI|LGH[RL]?|LGII?|LGMH|LGR?|LGRP|LGSW?|LH[ILRY]?|LHHR|LHRL|LHY|LKPAI?|LLB[HLR]?|LLC[HLR]?|LLD[HLR]?|LLESG?|LLGC[HR]?|LLGF[HR]?|LLGFRL|LLGHR?|LLGTR?|LLH[HR]?|LLHRL|LLIHF|LLIHH|LLIHL|LLILF|LLILH|LLILL|LLZRGF|LM[GH]?|LMD|LNDFR?|LNG[FR]?|LNGR|LNR?|LNXBR|LPDFR?|LPG[FR]?|LPGR|LPR?|LPXBR|LR[DFGV]?|LRL|LRV[GH]?|LRVGR?|LT[GY]?|LTDBR?|LTEBR?|LTGFR?|LTGR?|LTGF?|LTR?|LTXBR?|LTXTR?|LXDBR?|LXDTR?|LXEBR?|LXETR?|LXLBR|LXSBR|M[ACG]?|MA[CDY]?|MC|MDB[IR]?|MDTR?|MEEBR?|MH[IY]?|MLG?R?|MOD[FI]?|MP|MSG[FIR]?|MS[DFIYRP]?|MVC[DKL]?|MVCP?S?|MVGHI|MVI[Y]?|MVN|MVO|MVS|MVZ|NIAI|NC|NI[Y]?|NGR?|NIHF|NIHH|NIHL|NILF|NILH|NILL|NOP[R]?|NR?|OC|OI[Y]?|OGR?|OIHF|OIHH|OIHL|OILF|OILH|OILL|OR?|PACK|PCC|PCKMO|PFD[RL]?|PFPO|PKA|PKU|PLO|POP|PR|PRNO|PTER?|QPACI?|RLL[G]?|RNSBG|ROSBG|RISBGN?|RISBHG|RISBLG|RXSBG|S[ALG]?|SAC|SACF|SCOND|SDB[IR]?|SDTR?|SEBR?|SGRK?|SFASR|SFPC|SHI?|SLAK?|SLBGR?|SLBR?|SLB|SLDA|SLDL|SLGFR?|SLGRK?|SLGR?|SLG[SY]?|SLLG|SLLK|SLL[KY]?|SLR[GK]?|SLRK|SLY?|SQDBR?|SQDR?|SQEBR?|SQXBR?|SRA[GK]?|SRAG?|SRDA|SRDL|SRLG|SRLK?|SRST[U]?|SRLU|SSAIR?|SSK|SSM|ST[ACKM]?|STCM[HY]?|STC[KY]?|STFLE?|STFPC|STG|STH[RL]?|STMG?[H]?|STRV[GH]?|SVC|SXR|SXTR?|SY?|TM[HY]?|TMHH|TMHL|TMLH|TMLL|TP|TPI|TR[?]?|TRE|TROO|TROOT|TROT|TRTE?[SU]?|TRTR?[EU]?|TRTT|TS|UNPK[U]?|VA[B]?|VC[EFK]?|VN[M]?|VSTR?|VX[E]?|WFC|WTC|XI[Y]?|XGR?|XC|XR?|ZAP|CLST|CVBG?|CVDG?|EX[RL]?|LM[GH]?|MVN|MVZ|TR|TRT[E]?[SU]?|BAKR|PR|BXHG?|BXLEG?)\b/,
-        { token: 'hlasm-keyword', next: '@operandLine' }],
+      // Fallback: any identifier is an operation code (machine instruction or user macro)
+      [/[A-Z$#@][A-Z0-9$#_@]*/, { token: 'hlasm-keyword', next: '@operandLine' }],
 
-      { include: '@operandRest' },
+      // Empty line or end of field
+      [/$/, { token: '', next: '@popall' }],
     ],
 
     operandLine: [

--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -17,7 +17,7 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 import { BPXPRM_HILITE } from './hiliters/bpxprm';
 import { CEEDUMP_HILITE, CEE_MESSAGES, CEEDUMP_HOVER_DOCS, CEE_RUNOPTS } from './hiliters/ceedump';
-import { HLASM_HILITE } from './hiliters/hlasm';
+import { HLASM_HILITE, HLASM_DIRECTIVES, HLASM_MACRO_INSTS, HLASM_INSTRUCTIONS } from './hiliters/hlasm';
 import { IEASYS_HILITE } from './hiliters/ieasys';
 import { JCL_HILITE } from './hiliters/jcl';
 import { REXX_HILITE } from './hiliters/rexx';
@@ -113,6 +113,26 @@ export const CEEDUMP_DARK: Theme = {
     { token: 'cee-separator',     foreground: '666666' },                              // Dark gray
     // Runtime option names in the RPTOPTS section
     { token: 'cee-runopt',        foreground: 'd4a017', fontStyle: 'bold underline' }, // Amber bold underline
+  ]
+};
+
+export const HLASM_DARK: Theme = {
+  base: 'vs-dark',
+  inherit: true,
+  colors: {},
+  rules: [
+    { token: 'hlasm-comment',    foreground: '20e5e6' },                              // Cyan (ISPF comment color)
+    { token: 'hlasm-label',      foreground: 'fffd23', fontStyle: 'bold' },          // Yellow bold
+    { token: 'hlasm-directive',  foreground: '50eb24', fontStyle: 'bold underline' }, // Green bold underline
+    { token: 'hlasm-macro-inst', foreground: 'eb9b34', fontStyle: 'bold underline' }, // Orange bold underline
+    { token: 'hlasm-keyword',    foreground: '50eb24', fontStyle: 'bold' },          // Green bold
+    { token: 'hlasm-register',   foreground: '00ffff', fontStyle: 'underline' },     // Cyan underline
+    { token: 'hlasm-string',     foreground: 'fdfdfd' },                              // White
+    { token: 'hlasm-number',     foreground: 'ff8c00' },                              // Orange
+    { token: 'hlasm-operator',   foreground: 'eb2424' },                              // Red
+    { token: 'hlasm-variable',   foreground: 'd4a017', fontStyle: 'italic' },        // Amber italic
+    { token: 'hlasm-seq',        foreground: 'a0a0ff' },                              // Light purple
+    { token: 'hlasm-cont',       foreground: 'ff4444', fontStyle: 'bold' },          // Red bold
   ]
 };
 
@@ -479,6 +499,63 @@ export class MonacoConfig {
     monaco.languages.setMonarchTokensProvider('ceedump', <any>CEEDUMP_HILITE);
     monaco.languages.setMonarchTokensProvider('hlasm', <any>HLASM_HILITE);
     monaco.languages.setMonarchTokensProvider('ieasys', <any>IEASYS_HILITE);
+
+    monaco.languages.registerHoverProvider('hlasm', {
+      provideHover: (model, position) => {
+        const word = model.getWordAtPosition(position);
+        if (!word) { return null; }
+        const token = word.word.toUpperCase();
+
+        // Assembler directives
+        if (HLASM_DIRECTIVES[token]) {
+          return { contents: [{ value: HLASM_DIRECTIVES[token] }] };
+        }
+
+        // Conditional-assembly / macro instructions
+        if (HLASM_MACRO_INSTS[token]) {
+          return { contents: [{ value: HLASM_MACRO_INSTS[token] }] };
+        }
+
+        // Machine instructions
+        if (HLASM_INSTRUCTIONS[token]) {
+          return { contents: [{ value: HLASM_INSTRUCTIONS[token] }] };
+        }
+
+        // Register names R0–R15
+        const regMatch = token.match(/^R([0-9]|1[0-5])$/);
+        if (regMatch) {
+          const num = parseInt(regMatch[1], 10);
+          const regDesc: Record<number, string> = {
+            0:  'General-purpose register 0. Subroutine return value; also used as a branch mask in BCR.',
+            1:  'General-purpose register 1. Parameter list pointer on entry to a routine; first arg in CALL linkage.',
+            2:  'General-purpose register 2. Second argument or work register.',
+            3:  'General-purpose register 3. Third argument or work register.',
+            4:  'General-purpose register 4. Fourth argument or base register.',
+            5:  'General-purpose register 5. Base register or work register.',
+            6:  'General-purpose register 6. Base register or work register.',
+            7:  'General-purpose register 7. Work register.',
+            8:  'General-purpose register 8. Work register.',
+            9:  'General-purpose register 9. Work register.',
+            10: 'General-purpose register 10. Work register.',
+            11: 'General-purpose register 11. Base register for the Program Unit (PU base).',
+            12: 'General-purpose register 12. Base register for the Load Module (common anchor area).',
+            13: 'General-purpose register 13. Save area / DSA pointer — holds the address of the 18-fullword register save area (or LE DSA).',
+            14: 'General-purpose register 14. Return address — the caller stores the return address here before branching.',
+            15: 'General-purpose register 15. Entry point register — on entry to a subroutine, contains the load address of the called routine; also the return code.',
+          };
+          return {
+            contents: [
+              { value: `**R${num} — General Purpose Register ${num}**` },
+              { value: regDesc[num] || 'General purpose register.' }
+            ]
+          };
+        }
+
+        return null;
+      }
+    });
+
+    monaco.editor.defineTheme('hlasm-dark', HLASM_DARK);
     monaco.languages.setMonarchTokensProvider('jcl', <any>JCL_HILITE);
     monaco.languages.setMonarchTokensProvider('rexx', <any>REXX_HILITE);
 

--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -521,31 +521,31 @@ export class MonacoConfig {
           return { contents: [{ value: HLASM_INSTRUCTIONS[token] }] };
         }
 
-        // Register names R0–R15
+        // Register names R0-R15
         const regMatch = token.match(/^R([0-9]|1[0-5])$/);
         if (regMatch) {
           const num = parseInt(regMatch[1], 10);
           const regDesc: Record<number, string> = {
-            0:  'General-purpose register 0. Subroutine return value; also used as a branch mask in BCR.',
-            1:  'General-purpose register 1. Parameter list pointer on entry to a routine; first arg in CALL linkage.',
-            2:  'General-purpose register 2. Second argument or work register.',
-            3:  'General-purpose register 3. Third argument or work register.',
-            4:  'General-purpose register 4. Fourth argument or base register.',
-            5:  'General-purpose register 5. Base register or work register.',
-            6:  'General-purpose register 6. Base register or work register.',
-            7:  'General-purpose register 7. Work register.',
-            8:  'General-purpose register 8. Work register.',
-            9:  'General-purpose register 9. Work register.',
-            10: 'General-purpose register 10. Work register.',
-            11: 'General-purpose register 11. Base register for the Program Unit (PU base).',
-            12: 'General-purpose register 12. Base register for the Load Module (common anchor area).',
-            13: 'General-purpose register 13. Save area / DSA pointer — holds the address of the 18-fullword register save area (or LE DSA).',
-            14: 'General-purpose register 14. Return address — the caller stores the return address here before branching.',
-            15: 'General-purpose register 15. Entry point register — on entry to a subroutine, contains the load address of the called routine; also the return code.',
+            0:  'Subroutine return value; also used as a branch mask in BCR.',
+            1:  'Parameter list pointer on entry to a routine',
+            2:  'Argument or work register',
+            3:  'Argument or work register',
+            4:  'Argument or base register',
+            5:  'Base or work register',
+            6:  'Base or work register',
+            7:  'Work register',
+            8:  'Work register',
+            9:  'Work register',
+            10: 'Work register',
+            11: 'Base register for Program Unit',
+            12: 'Base register for Load Module (common anchor area).',
+            13: 'Save area / DSA pointer',
+            14: 'Return address',
+            15: 'Entry point register; also the return code',
           };
           return {
             contents: [
-              { value: `**R${num} — General Purpose Register ${num}**` },
+              { value: `**R${num} -- General Purpose Register ${num}**` },
               { value: regDesc[num] || 'General purpose register.' }
             ]
           };
@@ -585,7 +585,7 @@ export class MonacoConfig {
             };
             return {
               contents: [
-                { value: `**${token}** — Language Environment message` },
+                { value: `**${token}** -- Language Environment message` },
                 { value: `Severity: **${severityNames[severity] || severity}**\n\nSee the IBM z/OS Language Environment Runtime Messages documentation for the full description.` }
               ]
             };
@@ -633,16 +633,16 @@ export class MonacoConfig {
             10: 'Work register.',
             11: 'Base register for the Program Unit. Points to the module entry point.',
             12: 'Base register for the Load Module. Points to the common anchor area (CAA).',
-            13: 'DSA pointer — contains the address of the current routine\'s Dynamic Storage Area (stack frame).',
-            14: 'Return address — contains the address to which the routine will return.',
-            15: 'Entry point register — on entry, contains the address of the routine that was called.',
+            13: 'DSA pointer -- contains the address of the current routine\'s Dynamic Storage Area (stack frame).',
+            14: 'Return address -- contains the address to which the routine will return.',
+            15: 'Entry point register -- on entry, contains the address of the routine that was called.',
           };
           const desc = gprDescriptions[num] !== undefined
             ? gprDescriptions[num]
             : 'General purpose register used for computation or addressing.';
           return {
             contents: [
-              { value: `**GPR${num} — General Purpose Register ${num}**` },
+              { value: `**GPR${num} -- General Purpose Register ${num}**` },
               { value: desc }
             ]
           };
@@ -652,7 +652,7 @@ export class MonacoConfig {
         if (fprMatch) {
           return {
             contents: [
-              { value: `**FPR${fprMatch[1]} — Floating Point Register ${fprMatch[1]}**` },
+              { value: `**FPR${fprMatch[1]} -- Floating Point Register ${fprMatch[1]}**` },
               { value: 'One of the z/Architecture floating-point registers (FPR0, FPR2, FPR4, FPR6 in the basic set plus 8 extended registers). Used for IEEE and IBM HFP floating-point computations.' }
             ]
           };
@@ -662,7 +662,7 @@ export class MonacoConfig {
         if (vrMatch) {
           return {
             contents: [
-              { value: `**VR${vrMatch[1]} — Vector Register ${vrMatch[1]}**` },
+              { value: `**VR${vrMatch[1]} -- Vector Register ${vrMatch[1]}**` },
               { value: '128-bit register in the z/Architecture Vector Facility. Used by SIMD vector instructions for integer, floating-point, and string operations.' }
             ]
           };

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -1272,6 +1272,10 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
         monaco.editor.setTheme('ceedump-dark');
         break;
       }
+      case 'hlasm': {
+        monaco.editor.setTheme('hlasm-dark');
+        break;
+      }
       default: {
         if (this._defaultTheme) {
           monaco.editor.setTheme(this._defaultTheme);


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes

This PR significantly enhances the existing HLASM language mode in the zlux-editor Monaco integration.

IBM High Level Assembler (HLASM) source files are central to z/OS systems programming, but the editor's previous HLASM support was skeletal — it had no keyword set, no theming, and no hover help. This PR replaces that stub with a full-featured language mode that provides syntax highlighting across the fixed-column HLASM statement layout, hover documentation for directives, conditional-assembly instructions, and ~170 machine mnemonics, and an appropriate dark theme.

Changes:
- **`webClient/src/app/editor/code-editor/monaco/hiliters/hlasm.ts`** -- complete rewrite containing:
  - `HLASM_DIRECTIVES`: Hover documentation for 48 assembler directives (ACONTROL through XATTR), including CSECT, DSECT, DC, DS, EQU, USING, LTORG, MACRO/MEND, and more.
  - `HLASM_MACRO_INSTS`: Hover documentation for 19 conditional-assembly and macro instructions (AIF, AGO, ANOP, GBLA/B/C, LCLA/B/C, SETA/B/C, ACTR, AREAD, etc.).
  - `HLASM_INSTRUCTIONS`: Hover documentation for ~170 machine instruction mnemonics covering load/store (L/LR/LG/LA/MVC/STM), arithmetic (+/-/x/÷ in 32- and 64-bit variants), compare, all branch extended mnemonics (BE/BNE/BH/BNH/BL/BNL/BZ/BNZ/BO/BNO and register forms), bitwise logic, shifts, decimal arithmetic, translate/convert, string ops, atomics (CS/CSG/CDS/CDSG), and common z/OS system macros (WTO, ABEND, SVC, MODESET, SDUMPX, ESTAEX, ATTACH, STIMER, ALESERV).
  - `HLASM_HILITE`: Monarch tokenizer with states `root`, `mnemonic`, `operandLine`, and `operandRest`. Recognizes the fixed-column HLASM layout (col 1 = full-line comment, cols 1-8 = name field, col 10+ = mnemonic) as well as the 2-space-indented convention common in practice. Tokens emitted: `hlasm-comment`, `hlasm-label`, `hlasm-directive`, `hlasm-macro-inst`, `hlasm-keyword`, `hlasm-register`, `hlasm-string`, `hlasm-number`, `hlasm-operator`, `hlasm-variable` (`&sym`), `hlasm-seq` (`.sym`), `hlasm-cont`.
- **`webClient/src/app/editor/code-editor/monaco/monaco.config.ts`** -- updated to:
  - Import `HLASM_HILITE`, `HLASM_DIRECTIVES`, `HLASM_MACRO_INSTS`, and `HLASM_INSTRUCTIONS` from the new hlasm module.
  - Define and register the `hlasm-dark` theme (yellow labels, cyan comments, green directives, orange macro-insts, cyan underlined registers, red operators, amber italic variable symbols).
  - Register a hover provider for the `hlasm` language that resolves tokens against all three documentation maps and supplies per-register (R0-R15) z/OS calling-convention descriptions from the hover implementation directly.
- **`webClient/src/app/editor/code-editor/monaco/editor-control.service.ts`** -- added `case 'hlasm'` to `setThemeForLanguage()` so the dark theme activates automatically when a `.asm` or `.hlasm` file is opened.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

1. Build the editor plugin and deploy to a Zowe Desktop instance.
2. Open a `.asm` or `.hlasm` file via the File Explorer. The editor should automatically apply the HLASM language mode and `hlasm-dark` theme.
3. Verify syntax highlighting for a typical HLASM source file:
   - Full-line comments (`*` in column 1) appear in cyan.
   - Name-field labels (cols 1-8) appear in bright yellow bold.
   - Assembler directives (`CSECT`, `DSECT`, `DC`, `DS`, `EQU`, `USING`, `MACRO`, etc.) appear in green bold with underline.
   - Conditional-assembly instructions (`AIF`, `AGO`, `GBLA`, `SETA`, etc.) appear in amber/orange bold with underline.
   - Machine instruction mnemonics (`LR`, `ST`, `BNE`, `MVC`, etc.) appear in green bold.
   - Register operands (`R0`-`R15`) appear in cyan with underline.
   - Character, hex, and binary literals (`C'text'`, `X'FF'`, `B'1010'`) appear in orange.
   - Variable symbols (`&SYSPARM`, `&LOOP`) appear in amber italic.
   - Sequence symbols (`.LOOP`, `.EXIT`) appear in light purple.
   - End-of-line remarks appear in cyan (same as comments).
4. Hover over:
   - An assembler directive (`CSECT`, `USING`, `DC`, `EQU`, etc.) to see its hover tooltip.
   - A conditional-assembly instruction (`AIF`, `GBLA`, `SETC`) to see the tooltip.
   - A machine instruction (`LR`, `MVC`, `BCT`, `CS`) to see the tooltip.
   - A register reference (`R1`, `R13`, `R14`) to see its z/OS calling-convention role.
5. Manually switch the language mode to HLASM from the language picker and confirm it is listed.
6. Verify that the previous minimal HLASM tokenizer behavior (language registration) is preserved and no regressions occur.
