### PR TITLE
Add pli language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## `3.5.0`
 
 - Enhancement: Added CEEDUMP language mode. Files named `CEEDUMP.*` are automatically detected. It provides syntax highlighting and hover-help for headers, common messages, registers and more. 32-bit and 64-bit hex addresses are colored by byte significance to aid in pointer analysis.
-- Enhancement: HLASM language mode now has hover-help and improved syntax highlighting
+- Enhancement: HLASM language mode now has hover-help and improved syntax highlighting.
+- Enhancement: Added hover documentation to the JCL language mode. Hovering over JCL statement keywords (JOB, EXEC, DD, PROC, IF, INCLUDE, JCLLIB, etc.) and parameter names (DSN, DISP, SYSOUT, SPACE, DCB, RECFM, LRECL, CLASS, REGION, COND, etc.) now displays a brief description of the keyword's purpose and common usage. No changes to syntax highlighting or theme.
   
 ## `3.4.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## `3.5.0`
 
+- Enhancement: Added PL/I language mode. Files with `.pli`, `.pl1`, and `.pli1` extensions are automatically detected. It provides syntax highlighting and hover-help.
 - Enhancement: Added CEEDUMP language mode. Files named `CEEDUMP.*` are automatically detected. It provides syntax highlighting and hover-help for headers, common messages, registers and more. 32-bit and 64-bit hex addresses are colored by byte significance to aid in pointer analysis.
 - Enhancement: HLASM language mode now has hover-help and improved syntax highlighting.
 - Enhancement: Added hover documentation to the JCL language mode. Hovering over JCL statement keywords (JOB, EXEC, DD, PROC, IF, INCLUDE, JCLLIB, etc.) and parameter names (DSN, DISP, SYSOUT, SPACE, DCB, RECFM, LRECL, CLASS, REGION, COND, etc.) now displays a brief description of the keyword's purpose and common usage. No changes to syntax highlighting or theme.

--- a/webClient/src/app/editor/code-editor/monaco/hiliters/jcl.ts
+++ b/webClient/src/app/editor/code-editor/monaco/hiliters/jcl.ts
@@ -123,3 +123,99 @@ export const JCL_HILITE = {
     ]
   }
 };
+
+// -- Hover documentation --
+
+/**
+ * Hover documentation for JCL statement types, parameters, and common keywords.
+ * Keys are uppercase token strings as they appear in JCL source.
+ */
+export const JCL_HOVER_DOCS: Record<string, string> = {
+
+  // ---- Statement types ----
+  JOB:      '**JOB** -- Marks the beginning of a job. Identifies the job to the system, specifies accounting information, and sets job-level options such as CLASS, MSGCLASS, REGION, and NOTIFY.',
+  EXEC:     '**EXEC** -- Executes a program or procedure. Use PGM= to name a load module directly, or specify a cataloged or in-stream PROC name.',
+  DD:       '**DD** -- Data Definition. Describes a data set or I/O resource for a step. Required for every file opened by the program. Key parameters: DSN, DISP, UNIT, SPACE, DCB, SYSOUT.',
+  PROC:     '**PROC** -- Begins an in-stream procedure definition, or (on an EXEC statement) names a cataloged procedure to invoke.',
+  PEND:     '**PEND** -- Ends an in-stream procedure definition.',
+  IF:       '**IF** -- Conditional expression. Tests the return code or abend status of preceding steps. Format: `// IF (condition) THEN`.',
+  THEN:     '**THEN** -- Keyword following an IF condition. Statements between THEN and ELSE/ENDIF execute when the condition is true.',
+  ELSE:     '**ELSE** -- Optional clause of an IF/THEN/ELSE/ENDIF construct. Statements between ELSE and ENDIF execute when the IF condition is false.',
+  ENDIF:    '**ENDIF** -- Ends an IF/THEN/ELSE construct.',
+  INCLUDE:  '**INCLUDE** -- Substitutes the contents of a JCL library member at the point of the statement. The member must contain valid JCL.',
+  JCLLIB:   '**JCLLIB** -- Defines one or more private JCL procedure/include libraries to search before the system procedure libraries.',
+  OUTPUT:   '**OUTPUT** -- Associates output characteristics (destination, forms, copies, etc.) with SYSOUT data sets. Referenced by DD statements via OUTPUT=*.name.',
+  SET:      '**SET** -- Assigns a value to a symbolic parameter for use in the current JCL stream. The value replaces the symbol everywhere it appears in subsequent statements.',
+  CNTL:     '**CNTL** -- Begins a control statement group passed directly to a program (e.g. DFSORT, IEBGENER control statements). Paired with ENDCNTL.',
+  ENDCNTL:  '**ENDCNTL** -- Ends a CNTL block.',
+  XMIT:     '**XMIT** -- Transmit JCL -- marks data to be transmitted to another node.',
+  COMMAND:  '**COMMAND** -- Issues a z/OS operator command as part of job execution.',
+  EXPORT:   '**EXPORT** -- Makes a symbol defined by SET available to called procedures.',
+  SCHEDULE: '**SCHEDULE** -- Associates a job with a scheduling environment for JES3.',
+  JOBGROUP: '**JOBGROUP** -- Begins a group of jobs that run together as a unit (JES3 job group).',
+  ENDGROUP: '**ENDGROUP** -- Ends a JOBGROUP definition.',
+  GJOB:     '**GJOB** -- Defines a member job within a JOBGROUP.',
+  JOBSET:   '**JOBSET** -- Defines a set of jobs within a JOBGROUP that share execution criteria.',
+  SJOB:     '**SJOB** -- Names a specific job within a JOBSET.',
+  ENDSET:   '**ENDSET** -- Ends a JOBSET definition.',
+  AFTER:    '**AFTER** -- Specifies that a job or job group runs after another job or group completes.',
+  BEFORE:   '**BEFORE** -- Specifies that a job or job group runs before another.',
+  CONCURRENT: '**CONCURRENT** -- Allows jobs in a group to run at the same time.',
+
+  // ---- JOB statement parameters ----
+  CLASS:    '**CLASS** -- Job class (A-Z, 0-9). Determines which initiator can select the job. Configured by the installation.',
+  MSGCLASS: '**MSGCLASS** -- Output class for the job log (JES message data set). Typically A=held, X=print-and-delete, H=hold.',
+  MSGLEVEL: '**MSGLEVEL** -- Controls what appears in the job log. Format: `MSGLEVEL=(stmts,msgs)`. stmts: 0=JOB only, 1=all input, 2=only referenced. msgs: 0=none, 1=all JES and allocation messages.',
+  NOTIFY:   '**NOTIFY** -- TSO user ID to notify when the job completes. The system sends a message to that user\'s terminal.',
+  REGION:   '**REGION** -- Maximum virtual storage for a step or job. Format: `REGION=nnnK` or `REGION=nM`. 0M = no limit (up to system maximum). Also set on EXEC to override per-step.',
+  TIME:     '**TIME** -- CPU time limit. Format: `TIME=(minutes,seconds)` or `TIME=nnn` (seconds). Terminate job if exceeded. Use TIME=NOLIMIT or TIME=1440 for no limit.',
+  ADDRSPC:  '**ADDRSPC** -- Address space type: VIRT (virtual storage, default) or REAL (fixed real storage, discourages paging).',
+  COND:     '**COND** -- Condition for skipping a step. Format: `COND=(code,operator)` or `COND=(code,operator,stepname)`. Operators: LT, LE, EQ, NE, GE, GT. Step is bypassed if condition is true. COND=EVEN or COND=ONLY for abend handling.',
+  ACCT:     '**ACCT** -- Accounting information passed to the installation\'s accounting routine. Format is installation-defined.',
+  TYPRUN:   '**TYPRUN** -- Special job execution mode: SCAN (syntax-check JCL only), HOLD (hold before execution), COPY (copy JCL to SYSOUT).',
+  RESTART:  '**RESTART** -- Restart a failed job from a specified step: `RESTART=stepname` or `RESTART=stepname.procstep`.',
+  BYTES:    '**BYTES** -- Limits the total bytes of SYSOUT output for the job. Exceeded jobs are cancelled.',
+  LINES:    '**LINES** -- Limits the total lines of SYSOUT output for the job.',
+  PAGES:    '**PAGES** -- Limits the total pages of SYSOUT output for the job.',
+  CARDS:    '**CARDS** -- Limits the number of punch card images written to SYSOUT.',
+  PRTY:     '**PRTY** -- JES2 job priority within the job class (0-15, higher = more priority).',
+  PERFORM:  '**PERFORM** -- Performance group number assigned to the job for WLM/SRM scheduling.',
+
+  // ---- EXEC statement parameters ----
+  PGM:      '**PGM** -- Names the load module (program) to execute. The system searches the JOBLIB, STEPLIB, and link pack. Example: `EXEC PGM=IEFBR14`.',
+  PARM:     '**PARM** -- Character string passed to the program as its parameter (register 1 -> halfword length + data). Maximum 100 characters. Enclose in apostrophes if it contains special characters.',
+  DYNAMNBR: '**DYNAMNBR** -- Maximum number of data sets that can be dynamically allocated by this step.',
+
+  // ---- DD statement parameters ----
+  DSN:      '**DSN (DSNAME)** -- Data Set Name. Identifies the data set. Multi-level names use periods as qualifiers (up to 44 characters total). Special values: `&&name` = temporary, `*` = inline data, `NULLFILE` / `DUMMY` = no I/O.',
+  DISP:     '**DISP** -- Disposition. Format: `DISP=(status,normal,abnormal)`. Status: NEW, OLD, SHR, MOD. Normal/Abnormal: KEEP, DELETE, CATLG, UNCATLG, PASS. Example: `DISP=(NEW,CATLG,DELETE)`.',
+  UNIT:     '**UNIT** -- Device type or group name for the data set. Examples: SYSDA (any direct-access), 3390 (DASD model), TAPE, VIO (virtual I/O). Can also specify a specific device address.',
+  VOL:      '**VOL (VOLUME)** -- Volume serial or volume count. Format: `VOL=SER=volser` or `VOL=(PRIVATE,,n,SER=(v1,v2,...))`. Use to override catalog or specify multi-volume data sets.',
+  SYSOUT:   '**SYSOUT** -- Directs output to the JES spool rather than a real data set. Format: `SYSOUT=class` (e.g. SYSOUT=*=same as MSGCLASS, SYSOUT=A=print). Can include writer name: `SYSOUT=(class,writer)`.',
+  SPACE:    '**SPACE** -- Allocates DASD space. Format: `SPACE=(unit,(primary,secondary,directory))`. Unit: TRK, CYL, or blocksize. Example: `SPACE=(TRK,(10,5))` = 10 primary + 5 secondary tracks.',
+  DCB:      '**DCB** -- Data Control Block attributes. Common sub-parameters: RECFM, LRECL, BLKSIZE, DSORG. Can reference another DD: `DCB=*.stepname.ddname`. Example: `DCB=(RECFM=FB,LRECL=80,BLKSIZE=27920)`.',
+  RECFM:    '**RECFM** -- Record Format (DCB sub-parameter). Common values: F=fixed, FB=fixed-blocked, V=variable, VB=variable-blocked, U=undefined. Suffix A=ASA carriage control, M=machine carriage control.',
+  LRECL:    '**LRECL** -- Logical Record Length in bytes (DCB sub-parameter). For variable records, includes the 4-byte RDW. Maximum: 32760 for VS, 32756 for VBS.',
+  BLKSIZE:  '**BLKSIZE** -- Block size in bytes (DCB sub-parameter). Set to 0 to let the system determine the optimal block size. For tape: multiples of LRECL for fixed records.',
+  DSORG:    '**DSORG** -- Data Set Organization (DCB sub-parameter). PS=sequential, PO=partitioned (PDS), IS=indexed sequential, DA=direct.',
+  DUMMY:    '**DUMMY** -- Indicates a null DD -- no I/O actually occurs. The program opens and closes the file successfully but no data is read or written. Equivalent to DSN=NULLFILE,DISP=SHR.',
+  DDNAME:   '**DDNAME** -- Defers a DD to be supplied later by dynamic allocation or by a referencing concatenation.',
+  LABEL:    '**LABEL** -- Tape label type and sequence. Format: `LABEL=(seq,type,PASSWORD,RETPD=nnn,EXPDT=yyddd)`. Types: SL=IBM standard, NL=no label, SUL=standard+user, NSL=nonstandard.',
+  BUFNO:    '**BUFNO** -- Number of I/O buffers to allocate for this data set. Larger values improve sequential I/O throughput at the cost of virtual storage.',
+  FREE:     '**FREE** -- Controls when the data set is freed: END (at step end, default) or CLOSE (when the data set is closed). CLOSE is useful for long-running steps.',
+  AMP:      '**AMP** -- Access Method Parameters for VSAM data sets. Provides VSAM control information that cannot be expressed through other DD parameters.',
+  AVGREC:   '**AVGREC** -- Average record unit for space allocation: U=bytes, K=kilobytes, M=megabytes. Used with SPACE=(AVGREC,...).',
+  STORCLAS: '**STORCLAS** -- SMS Storage Class. Assigns the data set to a storage class defined in the SMS ACS routines for automatic storage management.',
+  MGMTCLAS: '**MGMTCLAS** -- SMS Management Class. Specifies backup, migration, and retention attributes for SMS-managed data sets.',
+  DATACLAS: '**DATACLAS** -- SMS Data Class. Provides default DCB and space attributes from an installation-defined template.',
+  KEYLEN:   '**KEYLEN** -- Key length for ISAM or VSAM data sets (DCB sub-parameter).',
+  RKP:      '**RKP** -- Relative Key Position: byte offset of the key within the record (DCB sub-parameter).',
+  EXPDT:    '**EXPDT** -- Expiration date for the data set: EXPDT=yyddd (Julian) or EXPDT=yyyy/ddd.',
+  RETPD:    '**RETPD** -- Retention period in days. The system calculates the expiration date as today + RETPD.',
+  SUBSYS:   '**SUBSYS** -- Names a subsystem (e.g. a database manager) to handle I/O for this DD.',
+  PATH:     '**PATH** -- HFS/zFS UNIX path name for z/OS UNIX files. Example: `PATH=\'/u/user/myfile.txt\'`.',
+  PATHMODE: '**PATHMODE** -- Permission bits for a newly created z/OS UNIX file (octal). Example: `PATHMODE=SIRWXU`.',
+  PATHOPTS: '**PATHOPTS** -- Open options for z/OS UNIX files: ORDWR (read/write), ORDONLY, OWRONLY, OCREAT, OTRUNC, etc.',
+  FILEDATA: '**FILEDATA** -- Indicates the data format for z/OS UNIX files: TEXT, BINARY, or RECORD.',
+};
+

--- a/webClient/src/app/editor/code-editor/monaco/hiliters/pli.ts
+++ b/webClient/src/app/editor/code-editor/monaco/hiliters/pli.ts
@@ -1,0 +1,548 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+/**
+ * Monarch tokenizer and hover documentation for IBM PL/I source files.
+ *
+ * PL/I is a block-structured, case-insensitive general-purpose language for IBM mainframes.
+ * Syntax reference: IBM Enterprise PL/I for z/OS Language Reference
+ *
+ * Token classes emitted:
+ *   pli-comment      -- block comments / * ... * / and line comments //
+ *   pli-keyword      -- statement and control flow keywords (PROCEDURE, IF, DO, DECLARE, ...)
+ *   pli-attribute    -- data type and variable attribute keywords (FIXED, FLOAT, CHARACTER, ...)
+ *   pli-builtin      -- built-in function names (SUBSTR, LENGTH, ADDR, NULL, ...)
+ *   pli-preprocessor -- preprocessor directives (%INCLUDE, %IF, *PROCESS, ...)
+ *   pli-string       -- character string literals ('...' or "...")
+ *   pli-number       -- numeric constants
+ *   pli-operator     -- operators and punctuation
+ */
+
+// -- Hover documentation -------------------------------------------------------
+
+/**
+ * PL/I keyword, attribute, and built-in hover documentation.
+ * Keys are uppercase; lookup is performed with toUpperCase().
+ */
+export const PLI_HOVER_DOCS: Record<string, string> = {
+
+  // --- Statement and control-flow keywords ------------------------------------
+
+  PROCEDURE: '**PROCEDURE** (abbrev: PROC) — Begins a procedure definition.\n\nSyntax: `label: PROCEDURE [(parameters)] [OPTIONS(options)] [RETURNS(type)];`\n\nA procedure acts as a subroutine or function. The matching `END label;` closes it.',
+  PROC: '**PROC** — Abbreviation for PROCEDURE. Begins a procedure definition.',
+  PACKAGE: '**PACKAGE** — Begins a package: a collection of procedures sharing a common scope.\n\nSyntax: `label: PACKAGE [EXPORTS(*|proc,...)] [RESERVES(*|var,...)] [OPTIONS(...)];`',
+  BEGIN: '**BEGIN** — Begins a BEGIN block, providing a new scope for local declarations.\n\nSyntax: `BEGIN [OPTIONS(...)]; statements END [label];`',
+  END: '**END** [label] — Closes a DO group, BEGIN block, SELECT, PROCEDURE, or PACKAGE.',
+
+  DO: '**DO** — Begins a DO group. Variants:\n- `DO;` — simple group\n- `DO WHILE(cond);` — loop while condition is true\n- `DO UNTIL(cond);` — loop until condition is true\n- `DO i = 1 TO n;` — counted iteration\n- `DO i = 1 TO n BY step;` — step iteration',
+  WHILE: '**WHILE(condition)** — Iterates a DO loop while condition is true.',
+  UNTIL: '**UNTIL(condition)** — Iterates a DO loop until condition becomes true.',
+  TO: '**TO** — Specifies the upper bound in a counted DO loop: `DO i = 1 TO n;`',
+  BY: '**BY** — Specifies the step value in a DO iteration: `DO i = 0 TO 100 BY 5;`',
+  UPTHRU: '**UPTHRU** — DO loop iterates upward through the end value (inclusive): `DO i = start UPTHRU end;`',
+  DOWNTHRU: '**DOWNTHRU** — DO loop iterates downward through the end value (inclusive): `DO i = start DOWNTHRU end;`',
+  REPEAT: '**REPEAT(expr)** — DO loop assigns the REPEAT expression to the control variable on each iteration.',
+
+  IF: '**IF condition THEN statement [ELSE statement]** — Conditional execution.',
+  THEN: '**THEN** — Introduces the true branch of an IF statement.',
+  ELSE: '**ELSE** — Introduces the false branch of an IF statement.',
+
+  SELECT: '**SELECT [(expr)];** — Multi-way conditional.\n\n```\nSELECT (x);\n  WHEN (1) stmt;\n  WHEN (2) stmt;\n  OTHERWISE stmt;\nEND;\n```',
+  WHEN: '**WHEN(conditions)** — Introduces a branch in a SELECT statement.',
+  OTHERWISE: '**OTHERWISE** — Default branch in a SELECT; executed when no WHEN condition matches.',
+  OTHER: '**OTHER** — Abbreviation for OTHERWISE.',
+
+  CALL: '**CALL procedure [(args)];** — Invokes a procedure as a statement (not a function call in an expression).',
+  RETURN: '**RETURN [(expression)];** — Returns from a procedure. For functions, returns the given value.',
+  STOP: '**STOP;** — Terminates program execution immediately.',
+  EXIT: '**EXIT;** — Terminates program execution (same effect as STOP).',
+  GOTO: '**GOTO label;** — Unconditional branch to a statement label. Also written `GO TO`.',
+  GO: '**GO TO label;** — Unconditional branch. Two-word form of GOTO.',
+  ITERATE: '**ITERATE [label];** — Transfers control back to the loop test of the enclosing (or labeled) DO loop.',
+  LEAVE: '**LEAVE [label];** — Exits a DO group, transferring control to the statement after END.',
+
+  DECLARE: '**DECLARE** (abbrev: DCL) — Declares variables with their storage and type attributes.\n\nSyntax: `DCL name attribute, ...; ` or `DCL (n1, n2) attribute;`\n\nExample: `DCL x FIXED BIN(31), s CHAR(80) VAR;`',
+  DCL: '**DCL** — Abbreviation for DECLARE.',
+  DEFAULT: '**DEFAULT** (abbrev: DFT) — Sets default attributes for identifiers matching a specified range pattern.',
+  DFT: '**DFT** — Abbreviation for DEFAULT.',
+
+  DEFINE: '**DEFINE** — Defines an alias, ordinal type, or structure type. Variants:\n- `DEFINE ALIAS name attributes;`\n- `DEFINE ORDINAL name (...);`\n- `DEFINE STRUCTURE level name;`',
+  XDEFINE: '**XDEFINE** — Extended DEFINE (IBM Enterprise PL/I extension).',
+
+  ALLOCATE: '**ALLOCATE** (abbrev: ALLOC) — Dynamically allocates storage for a BASED, CONTROLLED, or AREA variable.\n\nSyntax: `ALLOCATE var [IN(area)] [SET(ptr)];`',
+  ALLOC: '**ALLOC** — Abbreviation for ALLOCATE.',
+  FREE: '**FREE** — Releases storage previously allocated with ALLOCATE.',
+
+  ON: '**ON condition [SNAP] action;** — Installs an ON-unit (condition handler).\n\nExample: `ON ERROR BEGIN; PUT SKIP LIST(ONCODE()); END;`',
+  REVERT: '**REVERT condition;** — Removes a user-installed ON-unit, restoring default handling.',
+  RESIGNAL: '**RESIGNAL;** — Re-raises the current condition from within an ON-unit.',
+  SIGNAL: '**SIGNAL condition;** — Explicitly raises a condition.',
+
+  GET: '**GET** — Reads data. Variants: `GET FILE(f) LIST(...)`, `GET FILE(f) EDIT(...)`, `GET STRING(s) LIST(...)`, `GET DATA`.',
+  PUT: '**PUT** — Writes data. Variants: `PUT FILE(f) LIST(...)`, `PUT SKIP`, `PUT PAGE`, `PUT STRING(s) EDIT(...)`, `PUT DATA`.',
+  READ: '**READ FILE(f) [INTO(var)] [KEY(k)] [KEYTO(v)];** — Reads a record from a RECORD file.',
+  WRITE: '**WRITE FILE(f) FROM(var) [KEYFROM(k)] [KEYTO(v)];** — Writes a record to a RECORD file.',
+  REWRITE: '**REWRITE FILE(f) FROM(var) [KEY(k)];** — Updates the current (or keyed) record in a RECORD file.',
+  LOCATE: '**LOCATE var FILE(f) [SET(ptr)] [KEYFROM(k)];** — Allocates space for a BASED variable via a file buffer.',
+
+  OPEN: '**OPEN FILE(f) [INPUT|OUTPUT|UPDATE] [SEQUENTIAL|DIRECT] [...];** — Opens a file for I/O.',
+  CLOSE: '**CLOSE FILE(f);** — Closes a file.',
+  DELETE: '**DELETE FILE(f) [KEY(k)];** — Deletes a record from a KEYED RECORD file.',
+  FLUSH: '**FLUSH FILE(f);** — Flushes the file buffer to storage.',
+
+  FETCH: '**FETCH** entry [...];** — Dynamically loads a fetchable procedure into storage.',
+  RELEASE: '**RELEASE** (* | name, ...);** — Releases a dynamically fetched procedure.',
+  DELAY: '**DELAY(n);** — Suspends the current task for approximately n milliseconds.',
+  WAIT: '**WAIT THREAD(task);** — Waits for the specified task to complete.',
+  ATTACH: '**ATTACH** — Creates and starts a new multitasking task (thread).',
+  DETACH: '**DETACH THREAD(task);** — Detaches a task so that its completion is not awaited.',
+  CANCEL: '**CANCEL THREAD(task);** — Cancels a running task.',
+
+  ASSERT: "**ASSERT** — Runtime assertion. Variants:\n- `ASSERT TRUE(expr)` — asserts expression is true\n- `ASSERT FALSE(expr)` — asserts expression is false\n- `ASSERT COMPARE(actual, expected)` — asserts equality\n- `ASSERT UNREACHABLE` — asserts code point is never reached",
+  DISPLAY: '**DISPLAY(expr) [REPLY(var)];** — Writes a message to the operator console; optionally reads a reply.',
+  EXEC: '**EXEC** — Introduces an embedded statement for another language subsystem.\n\nCommon forms:\n- `EXEC SQL SELECT ... ;` — embedded SQL\n- `EXEC CICS command ;` — CICS commands',
+  FORMAT: '**FORMAT** — Defines a FORMAT label for use in GET EDIT / PUT EDIT format lists.',
+  QUALIFY: '**QUALIFY;** — Opens a QUALIFY block that qualifies all unqualified references within it.',
+  REINIT: '**REINIT var;** — Re-initializes a BASED variable to its INITIAL value.',
+
+  ENTRY: '**ENTRY** — (1) In a procedure: declares an additional entry point. (2) In a DCL: attribute indicating the variable is an entry (procedure reference).',
+  OPTIONS: '**OPTIONS(items)** — Specifies procedure, PACKAGE, or entry options. Common items: MAIN, RECURSIVE, REENTRANT, BYADDR, BYVALUE, FETCHABLE.',
+  EXPORTS: "**EXPORTS(*|proc,...)** — PACKAGE attribute listing which procedures are exported (visible outside the package). `EXPORTS(*)` exports all.",
+  RESERVES: "**RESERVES(*|var,...)** — PACKAGE attribute listing which variables are accessible from outside the package. `RESERVES(*)` allows all.",
+
+  // --- I/O and statement qualifiers -------------------------------------------
+
+  FILE: '**FILE(name)** — Identifies the file variable in I/O statements (READ, WRITE, OPEN, CLOSE, etc.).',
+  INTO: '**INTO(variable)** — Specifies the target variable for a READ or GET operation.',
+  FROM: '**FROM(variable)** — Specifies the source variable for a WRITE or REWRITE operation.',
+  IN: '**IN(area)** — Specifies the AREA in which to allocate a BASED variable.',
+  SET: '**SET(locator)** — Specifies the pointer or offset variable to be set by LOCATE, READ SET, or ALLOCATE SET.',
+  KEY: '**KEY(expression)** — Specifies the key value for direct-access or keyed file operations.',
+  KEYTO: '**KEYTO(variable)** — Specifies the variable to receive the key of the record just read.',
+  KEYFROM: '**KEYFROM(expression)** — Specifies the key value to use when writing a new record.',
+  TITLE: '**TITLE(expr)** — Specifies the data set name (ddname) to use when opening a file.',
+  COPY: '**COPY** — In GET: causes the data read to also be written to SYSPRINT.',
+  SKIP: '**SKIP [(n)]** — In PUT: advances n lines (default 1). In GET: skips n records.',
+  IGNORE: '**IGNORE(n)** — In READ: skips n records without reading them into storage.',
+  SNAP: '**SNAP** — In ON: requests a traceback dump when the condition is raised.',
+  SYSTEM: '**SYSTEM** — In ON: specifies that the system default action is to be taken for the condition.',
+  DATA: '**DATA** — In GET/PUT: uses data-directed I/O (name=value pairs).',
+  EDIT: '**EDIT(list)(format)** — In GET/PUT: uses format-directed I/O with explicit format items.',
+  LIST: '**LIST(items)** — In GET/PUT: uses list-directed (free-format) I/O.',
+  STRING: '**STRING(expr)** — (1) In GET/PUT: performs I/O from/to a character string rather than a file. (2) As a builtin: returns a structure\'s elements concatenated.',
+  REPLY: '**REPLY(variable)** — In DISPLAY: specifies a variable to receive the operator\'s reply.',
+  PAGE: '**PAGE** — In PUT: advances to the top of the next page.',
+  LINE: '**LINE(n)** — In PUT: advances to a specific line number on the current page. Also a format item.',
+  THREAD: '**THREAD(task)** — In WAIT/CANCEL/DETACH: identifies the task variable.',
+  ALIAS: '**ALIAS** — Used in `DEFINE ALIAS name type;` to create a type alias.',
+
+  AND: '**AND** — Logical AND operator (equivalent to `&` or `&&`). Used in expressions and DEFAULT range specifications.',
+  OR: '**OR** — Logical OR operator (equivalent to `|` or `||`). Used in expressions and DEFAULT range specifications.',
+  NOT: '**NOT** — Logical NOT operator (equivalent to `¬` or `^`). Used in DEFAULT range specifications.',
+
+  // --- Data type and attribute keywords ----------------------------------------
+
+  FIXED: '**FIXED** — Fixed-point numeric type. Precision and optional scale in parentheses.\n\nExample: `DCL x FIXED DEC(7,2);` — 7 total digits, 2 after the decimal.',
+  FLOAT: '**FLOAT** — Floating-point numeric type.\n\nExample: `DCL x FLOAT DEC(15);` — 15-digit decimal float (≈ double precision).',
+  DECIMAL: '**DECIMAL** (abbrev: DEC) — Decimal arithmetic base for FIXED or FLOAT.',
+  DEC: '**DEC** — Abbreviation for DECIMAL.',
+  BINARY: '**BINARY** (abbrev: BIN) — Binary arithmetic base for FIXED or FLOAT.\n\nExample: `DCL x FIXED BIN(31);` — 32-bit signed integer.',
+  BIN: '**BIN** — Abbreviation for BINARY.',
+  CHARACTER: '**CHARACTER** (abbrev: CHAR) — Character string type.\n\nExample: `DCL name CHAR(30) VAR;` — varying-length string of up to 30 characters.',
+  CHAR: '**CHAR** — Abbreviation for CHARACTER, and a built-in conversion function.',
+  BIT: '**BIT** — Bit string type.\n\nExample: `DCL flags BIT(8);` — 8-bit string.',
+  GRAPHIC: '**GRAPHIC** — DBCS (double-byte character set) string type.',
+  UCHAR: '**UCHAR** — Unicode character type (UTF-16 code units).',
+  WIDECHAR: '**WIDECHAR** — Wide character type (UCS-2 / UTF-16).',
+  PICTURE: '**PICTURE** (abbrev: PIC) — Picture-edited character type specifying the exact layout of digits and formatting.\n\nExample: `DCL amt PIC \'999V99\';`',
+  PIC: '**PIC** — Abbreviation for PICTURE.',
+  WIDEPIC: '**WIDEPIC** — Wide picture type for DBCS picture strings.',
+  REAL: '**REAL** — Specifies the real (non-complex) part of a number; opposite of COMPLEX.',
+  COMPLEX: '**COMPLEX** — Complex number type with real and imaginary parts.\n\nExample: `DCL z COMPLEX FLOAT DEC(15);`',
+  POINTER: '**POINTER** (abbrev: PTR) — Pointer type; holds the address of a storage location.\n\nExample: `DCL p POINTER; p = ADDR(x);`',
+  PTR: '**PTR** — Abbreviation for POINTER.',
+  OFFSET: '**OFFSET** — A relative address stored as an offset from the beginning of an AREA.',
+  LABEL: '**LABEL** — Label variable type; holds the address of a statement label.',
+  AREA: '**AREA** [(size)] — A region of storage used for allocating BASED variables.',
+  VARYING: '**VARYING** (abbrev: VAR) — Specifies a variable-length string. The length is stored explicitly.',
+  VAR: '**VAR** — Abbreviation for VARYING.',
+  VARYING4: '**VARYING4** — Variable-length string with a 4-byte length prefix.',
+  VARYINGZ: '**VARYINGZ** (abbrev: VARZ) — Null-terminated variable-length string (C-string layout).',
+  VARZ: '**VARZ** — Abbreviation for VARYINGZ.',
+  NONVARYING: '**NONVARYING** — Specifies a fixed-length string (default; opposite of VARYING).',
+  ALIGNED: '**ALIGNED** — Specifies that a variable is naturally aligned in storage.',
+  UNALIGNED: '**UNALIGNED** (abbrev: UNAL) — Specifies that a variable is packed without alignment padding.',
+  UNAL: '**UNAL** — Abbreviation for UNALIGNED.',
+  SIGNED: '**SIGNED** — Specifies a signed numeric data type.',
+  UNSIGNED: '**UNSIGNED** — Specifies an unsigned numeric data type.',
+  STATIC: '**STATIC** — Allocates the variable in static storage (persists for the program lifetime).',
+  AUTOMATIC: '**AUTOMATIC** (abbrev: AUTO) — Allocates the variable on the stack (default for local variables). Freed on return.',
+  AUTO: '**AUTO** — Abbreviation for AUTOMATIC.',
+  BASED: '**BASED** [(locator)] — A variable accessed through a pointer or offset locator.\n\nExample: `DCL node BASED(p); ALLOCATE node SET(p);`',
+  CONTROLLED: '**CONTROLLED** (abbrev: CTL) — Storage is explicitly allocated/freed with ALLOCATE/FREE. Supports a stack-like allocation model.',
+  CTL: '**CTL** — Abbreviation for CONTROLLED.',
+  DEFINED: '**DEFINED** (abbrev: DEF) — A DEFINED variable overlays the storage of a base variable.\n\nExample: `DCL overlay CHAR(2) DEF(base) POS(3);`',
+  DEF: '**DEF** — Abbreviation for DEFINED.',
+  EXTERNAL: '**EXTERNAL** (abbrev: EXT) — Variable or entry is visible outside the compilation unit (exported).',
+  EXT: '**EXT** — Abbreviation for EXTERNAL.',
+  INTERNAL: '**INTERNAL** (abbrev: INT) — Variable is local to the procedure (default; not exported).',
+  INT: '**INT** — Abbreviation for INTERNAL.',
+  BUILTIN: '**BUILTIN** — Declares a name as a reference to a PL/I built-in function, preventing it from being treated as a user variable.',
+  PARAMETER: '**PARAMETER** — Attribute indicating that a variable is a formal procedure parameter.',
+  VARIABLE: '**VARIABLE** — ENTRY attribute indicating the entry variable can refer to different procedures at run time.',
+  LIMITED: '**LIMITED** — ENTRY attribute restricting the associated entry to use only LIMITED operations.',
+  GENERIC: '**GENERIC** — ENTRY attribute associating a generic name with multiple specific entries selected by argument type.',
+  CONDITION: '**CONDITION(name)** — Declares a named condition that can be raised with SIGNAL and handled with ON.',
+  TASK: '**TASK** — Declares a task (multitasking) variable.',
+  EVENT: '**EVENT** — Declares an event variable used for task synchronization.',
+
+  SEQUENTIAL: '**SEQUENTIAL** (abbrev: SEQL) — Specifies sequential access order for a file.',
+  SEQL: '**SEQL** — Abbreviation for SEQUENTIAL.',
+  DIRECT: '**DIRECT** — Specifies direct (random-access) access order for a file.',
+  BUFFERED: '**BUFFERED** (abbrev: BUF) — Specifies that file I/O is buffered.',
+  BUF: '**BUF** — Abbreviation for BUFFERED.',
+  UNBUFFERED: '**UNBUFFERED** (abbrev: UNBUF) — Specifies that file I/O is unbuffered (each operation goes directly to storage).',
+  UNBUF: '**UNBUF** — Abbreviation for UNBUFFERED.',
+  KEYED: '**KEYED** — Specifies a file that supports keyed (direct) access.',
+  INPUT: '**INPUT** — Specifies that the file is opened for reading only.',
+  OUTPUT: '**OUTPUT** — Specifies that the file is opened for writing only.',
+  UPDATE: '**UPDATE** — Specifies that the file supports both reading and writing.',
+  PRINT: '**PRINT** — Specifies a print file (adds carriage control, PAGE/LINE/SKIP tracking).',
+  RECORD: '**RECORD** — Specifies record-oriented I/O (read/write complete records).',
+  STREAM: '**STREAM** — Specifies stream-oriented I/O (reads/writes data items, ignoring record boundaries).',
+  ENVIRONMENT: '**ENVIRONMENT** (abbrev: ENV) — Specifies file attributes such as block size and record format.',
+  ENV: '**ENV** — Abbreviation for ENVIRONMENT.',
+  EXCLUSIVE: '**EXCLUSIVE** — Specifies that a file is opened with exclusive access.',
+
+  DIMENSION: '**DIMENSION** (abbrev: DIM) — Specifies array dimensions. Can be omitted; dimension bounds are written directly: `DCL a(10,20) FIXED;`',
+  DIM: '**DIM** — Abbreviation for DIMENSION.',
+  INITIAL: '**INITIAL** (abbrev: INIT) — Specifies the initial value(s) for a declared variable.\n\nExample: `DCL x FIXED BIN(31) INIT(0);`',
+  INIT: '**INIT** — Abbreviation for INITIAL.',
+
+  LIKE: '**LIKE** — Declares a structure with the same layout as an existing named structure.\n\nExample: `DCL t2 LIKE t1;`',
+  TYPE: '**TYPE** — Specifies that a variable is an instance of a DEFINE\'d type.',
+  ORDINAL: '**ORDINAL** — Type attribute for `DEFINE ORDINAL` enumeration types.',
+  HANDLE: '**HANDLE** [(size)] — A typed pointer (handle) to a `DEFINE STRUCTURE` instance.',
+  RETURNS: '**RETURNS(type)** — Specifies the return type of a function procedure, or the return type in ENTRY/RETURNS attributes.',
+  PRECISION: '**PRECISION** (abbrev: PREC) — Specifies the precision (and optional scale) of a numeric variable.',
+  PREC: '**PREC** — Abbreviation for PRECISION.',
+  POSITION: '**POSITION** (abbrev: POS) — Used with DEFINED to specify the bit or character position within the base variable.',
+  POS: '**POS** — Abbreviation for POSITION.',
+  DATE: '**DATE** [(pattern)] — Declares a DATE variable with an optional date-string pattern (e.g., `\'YYYYMMDD\'`).',
+  STRUCTURE: '**STRUCTURE** — In `DEFINE STRUCTURE`: creates a named structure type.',
+  STRUCT: '**STRUCT** — Abbreviation for STRUCTURE in `DEFINE STRUCT`.',
+  UNION: '**UNION** — In `DEFINE STRUCTURE` or DCL: declares a union overlay of its members.',
+  VALUE: '**VALUE(expr)** — Specifies a compile-time constant value for a declared name.',
+  VALUELIST: '**VALUELIST(v1, v2, ...)** — Restricts a parameter or return value to one of the listed values.',
+  VALUERANGE: '**VALUERANGE(lo, hi)** — Restricts a parameter or return value to a specified range.',
+
+  RECURSIVE: '**RECURSIVE** — Procedure option permitting direct or indirect recursive calls.',
+  MAIN: '**MAIN** — Procedure option designating this procedure as the program entry point.',
+  BYADDR: '**BYADDR** — Passes parameters or return values by address (reference).',
+  BYVALUE: '**BYVALUE** — Passes parameters or return values by value (a copy is made).',
+  DESCRIPTOR: '**DESCRIPTOR** — Passes a string descriptor (dope vector) for character parameters.',
+  NODESCRIPTOR: '**NODESCRIPTOR** — Suppresses the descriptor for character parameters.',
+  REENTRANT: '**REENTRANT** — Declares that the code is re-entrant (safe for concurrent execution; no modifiable static data).',
+  REDUCIBLE: '**REDUCIBLE** — Declares that a function has no side effects and can be eliminated if its result is unused.',
+  IRREDUCIBLE: '**IRREDUCIBLE** — Declares that a function has side effects and must not be eliminated.',
+  NORETURN: '**NORETURN** — Declares that the procedure never returns (e.g., it always calls STOP).',
+  FETCHABLE: '**FETCHABLE** — PACKAGE/PROC option allowing the procedure to be dynamically loaded with FETCH.',
+  RENT: '**RENT** — Synonym for REENTRANT in the OPTIONS list.',
+  INLINE: '**INLINE** — Suggests that the procedure may be inlined at call sites.',
+  NOINLINE: '**NOINLINE** — Suppresses inlining of the procedure.',
+  ORDER: '**ORDER** — Evaluates DO-loop specifications in order (default).',
+  REORDER: '**REORDER** — Allows the compiler to reorder DO-loop specifications for optimization.',
+  ASSEMBLER: '**ASSEMBLER** (abbrev: ASM) — Specifies assembler calling convention for the entry.',
+  ASM: '**ASM** — Abbreviation for ASSEMBLER in OPTIONS.',
+  COBOL: '**COBOL** — Specifies COBOL calling linkage convention for an ENTRY.',
+  FORTRAN: '**FORTRAN** — Specifies FORTRAN calling linkage convention for an ENTRY.',
+  NOEXECOPS: '**NOEXECOPS** — Suppresses processing of runtime options from PARM.',
+
+  // --- Conditions (for ON / SIGNAL / REVERT) -----------------------------------
+
+  ERROR: '**ERROR** condition — Raised when a condition propagates without a matching ON-unit; the "catch-all" condition.',
+  FINISH: '**FINISH** condition — Raised when the program is about to terminate normally.',
+  CONVERSION: '**CONVERSION** condition — Raised on an invalid character-to-numeric conversion.',
+  OVERFLOW: '**OVERFLOW** (abbrev: OFL) condition — Raised on fixed-point overflow.',
+  OFL: '**OFL** — Abbreviation for OVERFLOW condition.',
+  UNDERFLOW: '**UNDERFLOW** (abbrev: UFL) condition — Raised on floating-point underflow.',
+  UFL: '**UFL** — Abbreviation for UNDERFLOW condition.',
+  ZERODIVIDE: '**ZERODIVIDE** (abbrev: ZDIV) condition — Raised when an integer division by zero occurs.',
+  ZDIV: '**ZDIV** — Abbreviation for ZERODIVIDE condition.',
+  FIXEDOVERFLOW: '**FIXEDOVERFLOW** (abbrev: FOFL) condition — Raised on fixed-point arithmetic overflow.',
+  FOFL: '**FOFL** — Abbreviation for FIXEDOVERFLOW condition.',
+  SUBSCRIPTRANGE: '**SUBSCRIPTRANGE** condition — Raised when an array subscript is out of the declared bounds.',
+  STRINGRANGE: '**STRINGRANGE** condition — Raised when a string pseudo-variable reference is outside the string bounds.',
+  STRINGSIZE: '**STRINGSIZE** condition — Raised when a string value is truncated on assignment.',
+  STORAGE: '**STORAGE** condition / builtin — As a condition: raised when ALLOCATE cannot obtain storage. As a builtin function: `STORAGE(var)` returns the number of bytes occupied by the variable.',
+  SIZE: '**SIZE** condition / builtin — As a condition: raised when a value is truncated due to precision loss on assignment. As a builtin: `SIZE(var)` returns the declared storage size in bytes.',
+  ENDFILE: '**ENDFILE(file)** condition — Raised when the end of file is reached on the specified file.',
+  ENDPAGE: '**ENDPAGE(file)** condition — Raised when the output page length limit is reached on a PRINT file.',
+  UNDEFINEDFILE: '**UNDEFINEDFILE** (abbrev: UNDF) condition — Raised when an attempt is made to use a file that is not defined or opened.',
+  UNDF: '**UNDF** — Abbreviation for UNDEFINEDFILE condition.',
+  TRANSMIT: '**TRANSMIT(file)** condition — Raised on a hardware I/O transmission error.',
+  INVALIDOP: '**INVALIDOP** condition — Raised on an invalid floating-point operation.',
+  ANYCONDITION: '**ANYCONDITION** (abbrev: ANYCOND) condition — Matches any condition not handled by a more specific ON-unit.',
+  ANYCOND: '**ANYCOND** — Abbreviation for ANYCONDITION.',
+  ATTENTION: '**ATTENTION** condition — Raised when an attention interrupt is received from the system operator.',
+  CONFORMANCE: '**CONFORMANCE** condition — Raised for XML/JSON conformance errors.',
+
+  // --- Preprocessor directives -------------------------------------------------
+
+  '%INCLUDE': '**%INCLUDE member;** — Includes source text from a library member at compile time. Equivalent to a source-level COPY.',
+  '%IF': '**%IF condition %THEN ... [%ELSE ...] %ENDIF;** — Conditional compilation block.',
+  '%DO': '**%DO;** — Begins a compile-time DO group in a preprocessor procedure.',
+  '%END': '**%END;** — Closes a compile-time %DO group or %PROCEDURE.',
+  '%DECLARE': '**%DECLARE name CHARACTER;** — Declares a compile-time (preprocessor) variable for text substitution.',
+  '%GOTO': '**%GOTO label;** — Unconditional branch at compile time.',
+  '%PROCEDURE': '**%PROCEDURE** — Begins a compile-time preprocessor procedure.',
+  '%RETURN': '**%RETURN [(expr)];** — Returns from a compile-time preprocessor procedure.',
+  '%ACTIVATE': '**%ACTIVATE name;** — Activates a preprocessor variable so that its value is substituted in subsequent source text.',
+  '%DEACTIVATE': '**%DEACTIVATE name;** — Deactivates preprocessor substitution for the named variable.',
+  '%NOTE': '**%NOTE(message [, severity]);** — Emits a compile-time informational message in the listing.',
+  '%PROCESS': '**%PROCESS** (or `*PROCESS`) — Specifies compile-time options on the first source record.',
+  '%SKIP': '**%SKIP [(n)];** — Skips n lines in the compiler listing (default 1).',
+  '%PAGE': '**%PAGE;** — Advances to a new page in the compiler listing.',
+  '%PRINT': '**%PRINT;** — Resumes printing of source lines in the compiler listing.',
+  '%NOPRINT': '**%NOPRINT;** — Suppresses printing of source lines in the compiler listing.',
+  '%POP': '**%POP;** — Restores a previously pushed compiler listing print state.',
+  '%PUSH': '**%PUSH;** — Saves the current compiler listing print state.',
+
+  // --- Built-in functions (most frequently used) --------------------------------
+
+  SUBSTR: '**SUBSTR(str, start [, len])** — Returns a substring. Also a pseudo-variable on the left side of assignment.\n\nExample: `SUBSTR(s, 1, 3) = \'ABC\';`',
+  LENGTH: '**LENGTH(string)** — Returns the current length of a VARYING string, or the declared length of a fixed string.',
+  ADDR: '**ADDR(var)** — Returns a POINTER to the storage location of the variable.',
+  ADDRBASED: '**ADDRBASED(ptr)** — Returns the POINTER value of the variable addressed by ptr.',
+  NULL: '**NULL()** — Returns a null POINTER value.',
+  SYSNULL: '**SYSNULL()** — Returns the system null pointer (equivalent to NULL() on most platforms).',
+  ABS: '**ABS(x)** — Returns the absolute value of x.',
+  MAX: '**MAX(x, y, ...)** — Returns the largest of the given numeric values.',
+  MIN: '**MIN(x, y, ...)** — Returns the smallest of the given numeric values.',
+  MOD: '**MOD(x, y)** — Returns x modulo y (remainder after division).',
+  SQRT: '**SQRT(x)** — Returns the square root of x.',
+  EXP: '**EXP(x)** — Returns e raised to the power x.',
+  LOG: '**LOG(x)** — Returns the natural logarithm of x.',
+  LOG2: '**LOG2(x)** — Returns the base-2 logarithm of x.',
+  LOG10: '**LOG10(x)** — Returns the base-10 logarithm of x.',
+  SIN: '**SIN(x)** — Returns the sine of x (x in radians).',
+  COS: '**COS(x)** — Returns the cosine of x (x in radians).',
+  TAN: '**TAN(x)** — Returns the tangent of x (x in radians).',
+  ATAN: '**ATAN(x [, y])** — Returns the arctangent of x, or of x/y.',
+  FLOOR: '**FLOOR(x)** — Returns the largest integer ≤ x.',
+  CEIL: '**CEIL(x)** — Returns the smallest integer ≥ x.',
+  ROUND: '**ROUND(x, n)** — Returns x rounded to n decimal digits.',
+  TRUNC: '**TRUNC(x)** — Truncates x toward zero, returning the integer part.',
+  SIGN: '**SIGN(x)** — Returns -1, 0, or 1 depending on the sign of x.',
+  INDEX: '**INDEX(string, search [, start])** — Returns the position of search within string, or 0 if not found.',
+  VERIFY: '**VERIFY(string, ref [, start])** — Returns the position of the first character in string NOT in ref, or 0.',
+  TRANSLATE: '**TRANSLATE(string [, to [, from]])** — Translates characters in a string using a mapping table.',
+  TRIM: '**TRIM(string [, leading [, trailing]])** — Removes leading and/or trailing characters (default: spaces).',
+  LTRIM: '**LTRIM(string [, pad])** — Removes leading pad characters (default: spaces).',
+  RTRIM: '**RTRIM(string [, pad])** — Removes trailing pad characters (default: spaces).',
+  HIGH: '**HIGH(n)** — Returns a CHARACTER string of n bytes all equal to X\'FF\'.',
+  LOW: '**LOW(n)** — Returns a CHARACTER string of n bytes all equal to X\'00\'.',
+  HEX: '**HEX(string [, sep])** — Returns the hexadecimal representation of a character or bit string.',
+  UNSPEC: '**UNSPEC(var)** — Returns or sets the internal bit-string representation of any variable.',
+  SOURCEFILE: '**SOURCEFILE()** — Returns the name of the current source file as a character string.',
+  SOURCELINE: '**SOURCELINE()** — Returns the current source line number as a FIXED BIN(31).',
+  ONCODE: '**ONCODE()** — Returns the numeric condition code of the most recently raised condition.',
+  ONFILE: '**ONFILE()** — Returns the name of the file involved in the most recently raised file condition.',
+  ONLOC: '**ONLOC()** — Returns the program location string where the most recently raised condition occurred.',
+  ONSOURCE: '**ONSOURCE()** — Returns (or sets, as pseudo-variable) the source string for CONVERSION conditions.',
+  ONCHAR: '**ONCHAR()** — Returns (or sets) the offending character for a CONVERSION condition.',
+  PROD: '**PROD(array)** — Returns the product of all elements in an array.',
+  SUM: '**SUM(array)** — Returns the sum of all elements in an array.',
+  ALLOCATION: '**ALLOCATION(var)** — Returns the number of currently allocated generations of a CONTROLLED variable.',
+  EMPTY: '**EMPTY()** — Returns an empty AREA (used to initialize an AREA variable).',
+  ENTRYADDR: '**ENTRYADDR(entry)** — Returns a POINTER to the code address of the specified entry.',
+  MAXLENGTH: '**MAXLENGTH(string)** — Returns the declared maximum length of a VARYING string.',
+  POINTER: '**POINTER(offset, area)** — Converts an OFFSET to a POINTER by adding the AREA base address.',
+  COLLATE: '**COLLATE()** — Returns a 256-character string representing the entire character collating sequence.',
+  BOOL: '**BOOL(x, y, op)** — Performs a boolean operation (op) on each bit of two bit strings x and y.',
+  IMAG: '**IMAG(z)** — Returns the imaginary part of a complex number z.',
+  CONJG: '**CONJG(z)** — Returns the complex conjugate of z.',
+  DATETIME: '**DATETIME([format])** — Returns the current date and time as a formatted string.',
+  DAYS: '**DAYS(date [, format])** — Converts a date string to the number of days since a reference date.',
+  VALID: '**VALID(string, picture)** — Returns 1B if string conforms to the picture specification, 0B otherwise.',
+};
+
+// -- Monarch tokenizer ---------------------------------------------------------
+
+export const PLI_HILITE = {
+  defaultToken: '',
+  ignoreCase: true,
+
+  // Statement and control-flow keywords
+  keywords: [
+    'PROCEDURE', 'PROC', 'XPROC', 'XPROCEDURE', 'PACKAGE',
+    'BEGIN', 'END',
+    'DO', 'WHILE', 'UNTIL', 'TO', 'BY', 'UPTHRU', 'DOWNTHRU', 'REPEAT',
+    'IF', 'THEN', 'ELSE',
+    'SELECT', 'WHEN', 'OTHERWISE', 'OTHER',
+    'CALL', 'RETURN', 'STOP', 'EXIT', 'GOTO', 'GO', 'ITERATE', 'LEAVE',
+    'DECLARE', 'DCL', 'XDECLARE', 'XDCL', 'DEFAULT', 'DFT',
+    'DEFINE', 'XDEFINE',
+    'ALLOCATE', 'ALLOC', 'FREE',
+    'ON', 'REVERT', 'RESIGNAL', 'SIGNAL',
+    'GET', 'PUT', 'READ', 'WRITE', 'REWRITE', 'LOCATE',
+    'OPEN', 'CLOSE', 'DELETE', 'FLUSH',
+    'FETCH', 'RELEASE', 'DELAY', 'WAIT',
+    'ATTACH', 'DETACH', 'CANCEL', 'THREAD',
+    'ASSERT', 'DISPLAY',
+    'EXEC',
+    'FORMAT', 'QUALIFY', 'REINIT',
+    'ENTRY', 'OPTIONS', 'EXPORTS', 'RESERVES',
+    'FILE', 'INTO', 'FROM', 'IN', 'SET', 'KEY', 'KEYTO', 'KEYFROM',
+    'TITLE', 'COPY', 'SKIP', 'IGNORE', 'SNAP', 'SYSTEM',
+    'DATA', 'EDIT', 'LIST', 'STRING', 'REPLY', 'PAGE', 'LINE',
+    'AND', 'OR', 'NOT',
+    'ALIAS', 'UNION',
+    'TRUE', 'FALSE', 'COMPARE', 'UNREACHABLE', 'TEXT',
+  ],
+
+  // Data type and variable attribute keywords
+  attributes: [
+    'FIXED', 'FLOAT', 'DECIMAL', 'DEC', 'BINARY', 'BIN',
+    'CHARACTER', 'CHAR', 'BIT', 'GRAPHIC', 'UCHAR', 'WIDECHAR', 'AREA',
+    'PICTURE', 'PIC', 'WIDEPIC',
+    'REAL', 'COMPLEX',
+    'POINTER', 'PTR', 'OFFSET', 'LABEL',
+    'VARYING', 'VAR', 'VARYING4', 'VARYINGZ', 'VARZ', 'NONVARYING',
+    'ALIGNED', 'UNALIGNED', 'UNAL',
+    'SIGNED', 'UNSIGNED',
+    'STATIC', 'AUTOMATIC', 'AUTO', 'BASED', 'CONTROLLED', 'CTL',
+    'DEFINED', 'DEF', 'EXTERNAL', 'EXT', 'INTERNAL', 'INT',
+    'BUILTIN', 'PARAMETER', 'VARIABLE', 'LIMITED', 'GENERIC',
+    'CONDITION', 'TASK', 'EVENT',
+    'SEQUENTIAL', 'SEQL', 'DIRECT',
+    'BUFFERED', 'BUF', 'UNBUFFERED', 'UNBUF',
+    'KEYED', 'INPUT', 'OUTPUT', 'UPDATE', 'PRINT',
+    'RECORD', 'STREAM',
+    'ENVIRONMENT', 'ENV', 'EXCLUSIVE',
+    'CONNECTED', 'NONCONNECTED', 'NATIVE', 'NONNATIVE',
+    'ASSIGNABLE', 'NONASSIGNABLE', 'NONASGN', 'MEMBER',
+    'DIMENSION', 'DIM',
+    'INITIAL', 'INIT', 'INITACROSS',
+    'LIKE', 'TYPE', 'ORDINAL', 'HANDLE',
+    'RETURNS', 'PRECISION', 'PREC', 'POSITION', 'POS',
+    'DATE', 'STRUCTURE', 'STRUCT',
+    'VALUE', 'VALUELIST', 'VALUELISTFROM', 'VALUERANGE',
+    'RECURSIVE', 'MAIN', 'BYADDR', 'BYVALUE', 'DESCRIPTOR', 'NODESCRIPTOR',
+    'REENTRANT', 'REDUCIBLE', 'IRREDUCIBLE', 'NORETURN',
+    'FETCHABLE', 'RENT', 'AMODE31', 'AMODE64',
+    'INLINE', 'NOINLINE', 'ORDER', 'REORDER',
+    'ASSEMBLER', 'ASM', 'COBOL', 'FORTRAN', 'NOEXECOPS', 'WINMAIN', 'INTER',
+    'LINKAGE', 'CDECL', 'OPTLINK', 'STDCALL',
+    'CMPAT', 'NOMAP', 'NOMAPIN', 'NOMAPOUT',
+    'DLLINTERNAL', 'FROMALIEN', 'RETCODE', 'FROMALIEN',
+    // Condition names
+    'ANYCONDITION', 'ANYCOND', 'ASSERTION', 'ATTENTION',
+    'CONFORMANCE', 'CONVERSION', 'ERROR', 'FINISH',
+    'FIXEDOVERFLOW', 'FOFL', 'INVALIDOP',
+    'OVERFLOW', 'OFL', 'UNDERFLOW', 'UFL',
+    'SIZE', 'STORAGE', 'STRINGRANGE', 'STRINGSIZE', 'SUBSCRIPTRANGE',
+    'ZERODIVIDE', 'ZDIV',
+    'ENDFILE', 'ENDPAGE',
+    'UNDEFINEDFILE', 'UNDF', 'TRANSMIT',
+    // XML/JSON attributes
+    'XMLCONTENT', 'XMLIGNORE', 'XMLNAME', 'XMLATTR', 'XMLOMIT',
+    'JSONIGNORE', 'JSONTRIMR', 'JSONNAME', 'JSONNULL', 'JSOMOMIT',
+    'NULLINIT', 'NOINIT', 'INDFOR', 'BIGENDIAN', 'LITTLEENDIAN',
+    'BACKWARDS', 'NORMAL', 'OPTIONAL', 'TRANSIENT',
+    'OUTONLY', 'INONLY', 'INOUT',
+    'DIMACROSS', 'RANGE', 'DESCRIPTORS',
+  ],
+
+  // Built-in function names (not duplicated in keywords or attributes)
+  builtins: [
+    'ABS', 'ACOS', 'ADDR', 'ADDRBASED', 'ADDRDATA',
+    'ALLOCATION', 'ASIN', 'ATAN', 'ATAND', 'ATANH',
+    'BOOL', 'BYTE',
+    'CEIL', 'CHECK', 'COLLATE', 'COMPLETION', 'CONJG', 'COS', 'COSD', 'COSH',
+    'DATETIME', 'DAYS', 'DAYSTODATE', 'DAYSTOSECS',
+    'EMPTY', 'ENTRYADDR', 'EPSILON', 'ERF', 'ERFC', 'EXP',
+    'FLOOR',
+    'HEX', 'HIGH', 'IMAG', 'INDEX',
+    'LENGTH', 'LINENO', 'LOG', 'LOG10', 'LOG2', 'LOW', 'LOWER', 'LTRIM',
+    'MAXLENGTH', 'MAX', 'MIN', 'MOD',
+    'NULL',
+    'ONCHAR', 'ONCODE', 'ONCONDCOND', 'ONCONDID', 'ONCOUNT', 'ONFILE', 'ONINFO', 'ONKEY', 'ONLOC', 'ONSOURCE',
+    'PLACE', 'POINTER', 'POINTERADD', 'POINTERVAL', 'POLY', 'PRESENT', 'PROD', 'PUTENV',
+    'ROUND', 'RTRIM',
+    'SEARCH', 'SEARCHR', 'SIGN', 'SIN', 'SIND', 'SINH', 'SOURCEFILE', 'SOURCELINE', 'SQRT', 'SUBSTR', 'SUM', 'SYSNULL',
+    'TAN', 'TAND', 'TANH', 'TIME', 'TRANSLATE', 'TRIM', 'TRUNC',
+    'UNALLOCATED', 'UNSPEC',
+    'VALID', 'VARGLIST', 'VARGLISTSIZE', 'VERIFY', 'VERIFYR',
+    'WCHAR', 'WCHARVAL',
+  ],
+
+  tokenizer: {
+    root: [
+      // Block comments /* ... */
+      [/\/\*/, 'pli-comment', '@blockComment'],
+
+      // Line comments //
+      [/\/\/.*$/, 'pli-comment'],
+
+      // *PROCESS / *PROCINC compiler options record (start of line)
+      [/^\s*\*PROC(?:INC)?\b.*$/, 'pli-preprocessor'],
+
+      // Preprocessor directives starting with %
+      [/%[A-Z][A-Z0-9]*/, 'pli-preprocessor'],
+
+      // String literals — single-quoted (with optional type suffix after closing quote)
+      [/'/, 'pli-string', '@singleString'],
+
+      // String literals — double-quoted
+      [/"/, 'pli-string', '@doubleString'],
+
+      // Numeric literals: integer, decimal, floating-point with optional exponent and type suffix
+      [/(?:\d[\d_]*(?:\.[\d_]+)?|\.[\d_]+)(?:[eEsEdDqQ][-+]?\d+)?(?:[bBiI]*)/, 'pli-number'],
+
+      // Identifiers: match keywords, attributes, builtins, then fall through to default
+      [/[A-Z_$@#][A-Z0-9_$@#]*/, {
+        cases: {
+          '@keywords':   'pli-keyword',
+          '@attributes': 'pli-attribute',
+          '@builtins':   'pli-builtin',
+          '@default':    '',
+        }
+      }],
+
+      // Operators: arithmetic, comparison, boolean, assignment
+      [/[+\-*\/=<>!^¬&|]/, 'pli-operator'],
+      [/[,;:().\[\]{}]/, 'pli-operator'],
+
+      // Whitespace (passthrough)
+      [/\s+/, ''],
+    ],
+
+    blockComment: [
+      [/[^*/]+/, 'pli-comment'],
+      [/\*\//, 'pli-comment', '@pop'],
+      [/[*/]/, 'pli-comment'],
+    ],
+
+    // Single-quoted strings; '' is an escaped single quote; optional type suffix (X, B, G, etc.)
+    singleString: [
+      [/''/, 'pli-string'],
+      [/[^']+/, 'pli-string'],
+      [/'[A-Za-z]*/, 'pli-string', '@pop'],
+    ],
+
+    // Double-quoted strings; "" is an escaped double quote; optional type suffix
+    doubleString: [
+      [/""/, 'pli-string'],
+      [/[^"]+/, 'pli-string'],
+      [/"[A-Za-z]*/, 'pli-string', '@pop'],
+    ],
+  }
+};

--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -19,7 +19,7 @@ import { BPXPRM_HILITE } from './hiliters/bpxprm';
 import { CEEDUMP_HILITE, CEE_MESSAGES, CEEDUMP_HOVER_DOCS, CEE_RUNOPTS } from './hiliters/ceedump';
 import { HLASM_HILITE, HLASM_DIRECTIVES, HLASM_MACRO_INSTS, HLASM_INSTRUCTIONS } from './hiliters/hlasm';
 import { IEASYS_HILITE } from './hiliters/ieasys';
-import { JCL_HILITE } from './hiliters/jcl';
+import { JCL_HILITE, JCL_HOVER_DOCS } from './hiliters/jcl';
 import { REXX_HILITE } from './hiliters/rexx';
 
 
@@ -557,6 +557,26 @@ export class MonacoConfig {
 
     monaco.editor.defineTheme('hlasm-dark', HLASM_DARK);
     monaco.languages.setMonarchTokensProvider('jcl', <any>JCL_HILITE);
+
+    monaco.languages.registerHoverProvider('jcl', {
+      provideHover: (model, position) => {
+        const word = model.getWordAtPosition(position);
+        if (!word) { return null; }
+        const token = word.word.toUpperCase();
+        if (JCL_HOVER_DOCS[token]) {
+          return { contents: [{ value: JCL_HOVER_DOCS[token] }] };
+        }
+        // Also check the line for parameter sub-keywords (RECFM=, LRECL=, etc.)
+        const line = model.getLineContent(position.lineNumber).toUpperCase();
+        // Match paramname= context around cursor column
+        const col = position.column - 1;
+        const paramMatch = line.slice(0, col + token.length).match(/([A-Z]+)=?$/);
+        if (paramMatch && JCL_HOVER_DOCS[paramMatch[1]]) {
+          return { contents: [{ value: JCL_HOVER_DOCS[paramMatch[1]] }] };
+        }
+        return null;
+      }
+    });
     monaco.languages.setMonarchTokensProvider('rexx', <any>REXX_HILITE);
 
     monaco.languages.registerHoverProvider('ceedump', {

--- a/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.config.ts
@@ -20,6 +20,7 @@ import { CEEDUMP_HILITE, CEE_MESSAGES, CEEDUMP_HOVER_DOCS, CEE_RUNOPTS } from '.
 import { HLASM_HILITE, HLASM_DIRECTIVES, HLASM_MACRO_INSTS, HLASM_INSTRUCTIONS } from './hiliters/hlasm';
 import { IEASYS_HILITE } from './hiliters/ieasys';
 import { JCL_HILITE, JCL_HOVER_DOCS } from './hiliters/jcl';
+import { PLI_HILITE, PLI_HOVER_DOCS } from './hiliters/pli';
 import { REXX_HILITE } from './hiliters/rexx';
 
 
@@ -61,6 +62,14 @@ const JCL_LANG = {
   filenamePatterns: ['\\.jcl\\.','\\.jcl','\\.cntl','\\.cntl\\.'],
   aliases: ['JCL', 'jcl'],
   mimetypes: ['application/jcl']
+};
+
+const PLI_LANG = {
+  id: 'pli',
+  extensions: ['.pli', '.pl1', '.pli1'],
+  filenamePatterns: ['\\.pli$', '\\.pl1$', '\\.pli1$'],
+  aliases: ['PL/I', 'PLI', 'pli', 'pl1'],
+  mimetypes: ['application/pli']
 };
 
 const REXX_LANG = {  
@@ -154,6 +163,22 @@ export const JCL_DARK: Theme = {
     { token: 'jcl-default', foreground: '50eb24' }, // Green
 	]
 }
+
+export const PLI_DARK: Theme = {
+  base: 'vs-dark',
+  inherit: true,
+  colors: {},
+  rules: [
+    { token: 'pli-comment',      foreground: '20e5e6' },                              // Cyan
+    { token: 'pli-keyword',      foreground: 'fffd23', fontStyle: 'bold' },          // Yellow bold
+    { token: 'pli-attribute',    foreground: '75abff' },                              // Light blue
+    { token: 'pli-builtin',      foreground: '50eb24', fontStyle: 'bold' },          // Green bold
+    { token: 'pli-preprocessor', foreground: 'd4a017', fontStyle: 'bold underline' }, // Amber bold underline
+    { token: 'pli-string',       foreground: 'fdfdfd' },                              // White
+    { token: 'pli-number',       foreground: 'ff8c00' },                              // Orange
+    { token: 'pli-operator',     foreground: 'eb2424' },                              // Red
+  ]
+};
 
 export const REXX_DARK: Theme = {
   base: 'vs-dark',
@@ -493,6 +518,7 @@ export class MonacoConfig {
     monaco.languages.register(HLASM_LANG);
     monaco.languages.register(IEASYS_LANG);
     monaco.languages.register(JCL_LANG);
+    monaco.languages.register(PLI_LANG);
     monaco.languages.register(REXX_LANG);
 
     monaco.languages.setMonarchTokensProvider('bpxprm', <any>BPXPRM_HILITE);
@@ -577,6 +603,29 @@ export class MonacoConfig {
         return null;
       }
     });
+    monaco.languages.setMonarchTokensProvider('pli', <any>PLI_HILITE);
+
+    monaco.languages.registerHoverProvider('pli', {
+      provideHover: (model, position) => {
+        const word = model.getWordAtPosition(position);
+        if (!word) { return null; }
+        const token = word.word.toUpperCase();
+        if (PLI_HOVER_DOCS[token]) {
+          return { contents: [{ value: PLI_HOVER_DOCS[token] }] };
+        }
+        // Check for % prefixed preprocessor directives
+        const line = model.getLineContent(position.lineNumber);
+        const col = position.column - 1;
+        const ppMatch = line.slice(0, col + token.length).match(/(%[A-Z][A-Z0-9]*)$/i);
+        if (ppMatch && PLI_HOVER_DOCS[ppMatch[1].toUpperCase()]) {
+          return { contents: [{ value: PLI_HOVER_DOCS[ppMatch[1].toUpperCase()] }] };
+        }
+        return null;
+      }
+    });
+
+    monaco.editor.defineTheme('pli-dark', PLI_DARK);
+
     monaco.languages.setMonarchTokensProvider('rexx', <any>REXX_HILITE);
 
     monaco.languages.registerHoverProvider('ceedump', {

--- a/webClient/src/app/shared/editor-control/editor-control.service.ts
+++ b/webClient/src/app/shared/editor-control/editor-control.service.ts
@@ -1276,6 +1276,10 @@ export class EditorControlService implements ZLUX.IEditor, ZLUX.IEditorMultiBuff
         monaco.editor.setTheme('hlasm-dark');
         break;
       }
+      case 'pli': {
+        monaco.editor.setTheme('pli-dark');
+        break;
+      }
       default: {
         if (this._defaultTheme) {
           monaco.editor.setTheme(this._defaultTheme);


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes

This PR adds a full PL/I language mode to the zlux-editor Monaco integration.

Changes:
- **`webClient/src/app/editor/code-editor/monaco/hiliters/pli.ts`** — new file containing:
  - `PLI_HOVER_DOCS`: ~120 entries covering statement and control-flow keywords (`PROCEDURE`, `DO`, `IF`, `SELECT`, `DECLARE`, `ALLOCATE`, `ON`, `GET`/`PUT`/`READ`/`WRITE`/`OPEN`/`CLOSE`, etc.), data type and variable attribute keywords (`FIXED`, `FLOAT`, `BINARY`, `CHARACTER`, `POINTER`, `VARYING`, `BASED`, `CONTROLLED`, `EXTERNAL`, etc.), ON condition names (`ERROR`, `OVERFLOW`, `ENDFILE`, `ZERODIVIDE`, `CONVERSION`, `SUBSCRIPTRANGE`, etc.), preprocessor directives (`%INCLUDE`, `%IF`, `%DECLARE`, `%ACTIVATE`, `*PROCESS`, etc.), and common built-in functions (`SUBSTR`, `LENGTH`, `ADDR`, `NULL`, `ABS`, `INDEX`, `TRANSLATE`, `VERIFY`, `ONCODE`, `ONFILE`, `DATETIME`, etc.).
  - `PLI_HILITE`: Monarch tokenizer (`ignoreCase: true`) with three keyword sets matched against identifiers:
    - `keywords` — statement/control-flow words → token `pli-keyword` (yellow bold)
    - `attributes` — data type and variable attributes → token `pli-attribute` (light blue)
    - `builtins` — built-in function names → token `pli-builtin` (green bold)
    - Additional tokenizer rules for block comments (`/* ... */`), line comments (`//`), `%` preprocessor directives, `*PROCESS`/`*PROCINC` compiler option records, single- and double-quoted string literals (with `''`/`""` escape handling and type suffix), numeric literals (integer, decimal, floating-point with exponent and type suffix), and operators/punctuation.
- **`webClient/src/app/editor/code-editor/monaco/monaco.config.ts`** — updated to:
  - Import `PLI_HILITE` and `PLI_HOVER_DOCS` from the new pli module.
  - Define `PLI_LANG` and register the language for extensions `.pli`, `.pl1`, `.pli1`.
  - Define and apply the `pli-dark` theme (yellow keywords, light-blue attributes, green builtins, amber preprocessor directives, white strings, orange numbers, red operators/punctuation).
  - Register a hover provider for the `pli` language that resolves identifiers against `PLI_HOVER_DOCS` and also handles `%`-prefixed preprocessor directives in the hover context.
- **`webClient/src/app/shared/editor-control/editor-control.service.ts`** — added `case 'pli'` to `setThemeForLanguage()` so the `pli-dark` theme activates automatically when a `.pli` or `.pl1` file is opened.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

1. Build the editor plugin and deploy to a Zowe Desktop instance.
2. Open a `.pli` or `.pl1` file via the File Explorer. The editor should automatically apply the PL/I language mode and `pli-dark` theme.
3. Verify syntax highlighting for a typical PL/I source file:
   - Block comments (`/* ... */`) appear in cyan.
   - Line comments (`//`) appear in cyan.
   - Statement and control-flow keywords (`PROCEDURE`, `DO`, `IF`, `SELECT`, `DECLARE`, `CALL`, `RETURN`, `ON`, etc.) appear in yellow bold.
   - Data type and variable attribute words (`FIXED`, `BINARY`, `CHARACTER`, `POINTER`, `VARYING`, `BASED`, etc.) appear in light blue.
   - Built-in function names (`SUBSTR`, `LENGTH`, `ADDR`, `NULL`, `ABS`, etc.) appear in green bold.
   - Preprocessor directives (`%INCLUDE`, `%IF`, `%DECLARE`, `*PROCESS`) appear in amber bold with underline.
   - String literals (`'...'` and `"..."`) appear in white; `''` and `""` escaped quotes are handled correctly.
   - Numeric literals (integers, decimals, and floats with exponents) appear in orange.
   - Operators and punctuation (`;`, `,`, `(`, `)`, `=`, `+`, `-`, etc.) appear in red.
   - Unrecognized identifiers (variable names, structure tags, labels) receive no special coloring.
4. Hover over:
   - A statement keyword (`PROCEDURE`, `DECLARE`, `DO`, `IF`, `ON`, `ALLOCATE`, etc.) to see its hover tooltip.
   - A data attribute keyword (`FIXED`, `CHARACTER`, `POINTER`, `VARYING`, `BASED`, etc.) to see the tooltip.
   - A built-in function name (`SUBSTR`, `ADDR`, `NULL`, `ONCODE`, `DATETIME`) to see the tooltip.
   - An ON condition name (`ERROR`, `ENDFILE`, `OVERFLOW`, `ZERODIVIDE`) to see the tooltip.
   - A preprocessor directive word (e.g., position cursor on `INCLUDE` in a `%INCLUDE` line) to see the tooltip.
5. Manually switch the language mode to PL/I from the language picker and confirm it is listed as `PL/I` / `PLI`.
6. Verify `.pl1` files are also detected automatically.
