### PR TITLE
Order language list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Zlux Editor Changelog
 
+## `3.5.0`
+
+- Enhancement: Language selection menu now groups popular mainframe and web languages (HLASM, REXX, JCL, COBOL, Java, C, C++, JavaScript, TypeScript, Python, JSON, YAML, Plaintext) at the top, separated from the full alphabetical list.
+
+
 ## `3.4.0`
 
 - Enhancement: Re-enabled JCL submit via submit menu and ability to view submitted job via JES Explorer desktop app.

--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -293,32 +293,49 @@ export class MenuBarComponent implements OnInit, OnDestroy {
   }
 
   private resetLanguageSelectionMenu() {
-    this.languageSelectionMenu.children = this.monaco.languages.getLanguages()
-      .filter(lang => !_.isEmpty(lang.aliases))
-      .sort((lang1, lang2) => {
-        let name1 = lang1?.aliases[0]?.toLowerCase();
-        let name2 = lang2?.aliases[0]?.toLowerCase();
-        if (name1 < name2) {
-          return -1;
-        } else if (name1 > name2) {
-          return 1;
-        } else {
-          return 0;
-        }
-      }).map(language => {
-        return {
-          name: language.aliases[0],
-          type: 'checkbox',
-          action: {
-            internalName: 'setEditorLanguage',
-            params: [language.id]
-          },
-          active: {
-            internalName: 'languageActiveCheck',
-            params: [language.id]
-          }
-        }
-      });
+    // Languages to feature at the top of the menu, in display order
+    const featuredLanguageIds = [
+      'hlasm', 'rexx', 'jcl', 'cobol', 'java', 'c', 'cpp',
+      'javascript', 'typescript', 'python', 'json', 'yaml', 'plaintext'
+    ];
+
+    const allLanguages = this.monaco.languages.getLanguages()
+      .filter(lang => !_.isEmpty(lang.aliases));
+
+    const toMenuItem = (language) => ({
+      name: language.aliases[0],
+      type: 'checkbox',
+      action: {
+        internalName: 'setEditorLanguage',
+        params: [language.id]
+      },
+      active: {
+        internalName: 'languageActiveCheck',
+        params: [language.id]
+      }
+    });
+
+    const alphabeticalSort = (lang1, lang2) => {
+      const name1 = lang1?.aliases[0]?.toLowerCase();
+      const name2 = lang2?.aliases[0]?.toLowerCase();
+      if (name1 < name2) { return -1; }
+      if (name1 > name2) { return 1; }
+      return 0;
+    };
+
+    const featuredLanguages = featuredLanguageIds
+      .map(id => allLanguages.find(lang => lang.id === id))
+      .filter(lang => lang != null);
+
+    const otherLanguages = allLanguages
+      .filter(lang => !featuredLanguageIds.includes(lang.id))
+      .sort(alphabeticalSort);
+
+    this.languageSelectionMenu.children = [
+      ...featuredLanguages.map(toMenuItem),
+      { name: 'group-end' },
+      ...otherLanguages.map(toMenuItem)
+    ];
   }
 
   private getReadableLangName(languageId) {


### PR DESCRIPTION
## Proposed changes

The language selection menu in the zlux-editor previously showed all available languages sorted alphabetically. This made it tedious for mainframe developers to find the few languages they use most often, as those languages were scattered throughout a large alphabetical list.

This PR adds a curated "featured" section at the top of the language menu containing the languages most commonly used by mainframe developers:

**HLASM, REXX, JCL, COBOL, Java, C, C++, JavaScript, TypeScript, Python, JSON, YAML, Plaintext**

A horizontal separator (`group-end`) divides the featured section from the full alphabetical list of all other languages below it. Any featured language not registered in the current Monaco instance is silently omitted. The ordering of the featured list is intentional and reflects typical mainframe workflow priority.

Only `resetLanguageSelectionMenu()` in `menu-bar.component.ts` was modified — no changes to the template, styles, or other services were required.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## PR Checklist

- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

1. Build and launch the zlux-editor plugin in a running Zowe Desktop.
2. Open any file to activate the **Language** menu in the menu bar.
3. Click the **Language** menu and verify:
   - The top of the list shows the featured languages in the following order: HLASM, REXX, JCL, COBOL, Java, C, C++, JavaScript, TypeScript, Python, JSON, YAML, Plaintext.
   - A horizontal separator (`<hr>`) appears below the featured group.
   - All other Monaco-registered languages appear below the separator, sorted alphabetically.
4. Select a featured language and confirm the editor switches to that language mode.
5. Select a language from the section below the separator and confirm the editor switches correctly.
6. Open a new file (so the Language menu is removed), then open another file and verify the language menu rebuilds correctly with the same grouping.