### PR TITLE
Fix monaco.Uri object vs string comparison in fileDuplicateChecker an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `3.5.0`
+
+- Bugfix: Fixed `fileDuplicateChecker` and `closeFile` comparing `monaco.Uri` objects against plain strings, which caused the editor to display stale file contents after closing and reopening files.
+
 ## `3.4.0`
 
 - Enhancement: Re-enabled JCL submit via submit menu and ability to view submitted job via JES Explorer desktop app.

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -373,7 +373,7 @@ export class MonacoService implements OnDestroy {
     const models = _editor.getModels();
     const fileUri = this.generateUri(fileNode.model);
     for (const model of models) {
-      if (model.uri === fileUri) {
+      if (model.uri.toString() === fileUri) {
         model.dispose();
         this.editorControl.saveCursorPosition = false;
       }
@@ -565,7 +565,7 @@ export class MonacoService implements OnDestroy {
   fileDuplicateChecker(uri: string): boolean {
     const models = this.editorControl.editorCore.getValue().editor.getModels();
     for (const model of models) {
-      if (model.uri === uri) {
+      if (model.uri.toString() === uri) {
         return true;
       }
     }


### PR DESCRIPTION
fileDuplicateChecker() and closeFile() in monaco.service.ts compare model.uri (a monaco.Uri object) against a plain string using ===. Since an object is never strictly equal to a string, both comparisons always evaluate to false.

This causes two issues:

Model memory leak — closeFile() never matches the model to dispose, so closed file/dataset models accumulate in memory for the lifetime of the editor session.

Dataset reopen failure — When reopening a dataset that was previously closed, fileDuplicateChecker() fails to detect the undisposed model. createModel() is then called with a duplicate URI, which throws an error in Monaco 0.52+.
