### PR TITLE
Update @zlux/widgets dependency to a specific commit

### DIFF
--- a/webClient/package.json
+++ b/webClient/package.json
@@ -12,7 +12,7 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@zlux/widgets": "github:wadkarsatish/zlux-widgets-angular18#widgets-Angular-Library",
+    "@zlux/widgets": "github:wadkarsatish/zlux-widgets-angular18#adcaa88e35374c89aefb0661d00d9306454ad50a",
     "@zowe/zlux-angular-file-tree": "2.0.0-staging-474-20250915115421",
     "lodash": "4.18.1",
     "material-icons": "1.13.14",


### PR DESCRIPTION
The private fork is used for Zowe Editor, probable reason is Angular 18 update is missing in main or staging of zlux-widgets. 
So at least (for now) use a specific commit.

Perfect solution would be checking the `wadkarsatish/zlux-widgets-angular18` and merging it into the staging.