### PR TITLE
Fix reverse tabnabbing / open redirect via window.open(r.url) from cleartext dev endpoint

### DIFF
--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -653,17 +653,6 @@ export class MenuBarComponent implements OnInit, OnDestroy {
     return `${item.name}`;
   }
 
-  graphicDiagram() {
-    let file = this.editorControl.fetchActiveFile();
-    if (!file) {
-      this.snackBar.open(`Please open a file before you generate a diagram.`, 'Close', { duration: MessageDuration.Long, panelClass: 'center' });
-    }
-    this.http.post(ENDPOINTS.diagram, { member: file.name, content: file.model.contents }).subscribe(r => {
-      window.open(r.url, '_blank');
-    });
-    this.snackBar.open(`A new window will open after the diagram generated.`, 'Close', { duration: MessageDuration.Long, panelClass: 'center' });
-  }
-
   submitJob() {
     let file = this.editorControl.fetchActiveFile();
     if (!file || (file.model.language !== 'jcl')) {

--- a/webClient/src/app/shared/model/endpoints.ts
+++ b/webClient/src/app/shared/model/endpoints.ts
@@ -19,7 +19,6 @@ export interface Endpoints {
     file: string;
     saveFile: string;
     searchInFile: string;
-    diagram: string;
     jobs: string;
 }
 

--- a/webClient/src/environments/environment.ts
+++ b/webClient/src/environments/environment.ts
@@ -30,7 +30,6 @@ export const ENDPOINTS: Endpoints = {
   file: 'http://rs22:5000/datasets/{dataset}/members/{member}',
   saveFile: 'http://rs22:5000/datasets/{dataset}/members/{member}',
   searchInFile: 'http://rs22:5000/projects/GCE/search?pattern={pattern}',
-  diagram: 'http://wal-vm-db2zos1:5000/genflow',
   jobs: 'http://rs22:5000/jobs'
 };
 

--- a/webClient/src/environments/environment.ts
+++ b/webClient/src/environments/environment.ts
@@ -26,11 +26,6 @@ export const ENDPOINTS: Endpoints = {
   asmFile: './mock/file.json',
   htmlFile: './mock/htmlFile.json',
   project: '../../com.rs.mvd.ide/web/mock/project.json',
-  projectFile: 'http://rs22:5000/datasets/{name}/members',
-  file: 'http://rs22:5000/datasets/{dataset}/members/{member}',
-  saveFile: 'http://rs22:5000/datasets/{dataset}/members/{member}',
-  searchInFile: 'http://rs22:5000/projects/GCE/search?pattern={pattern}',
-  jobs: 'http://rs22:5000/jobs'
   projectFile: '/datasets/{name}/members',
   file: '/datasets/{dataset}/members/{member}',
   saveFile: '/datasets/{dataset}/members/{member}',


### PR DESCRIPTION
## Proposed changes

This PR removes an unreachable, insecure code path in the zlux-editor menu bar. The `graphicDiagram()` method POSTed the active buffer's contents to a remote HTTP endpoint (`ENDPOINTS.diagram` -> `http://wal-vm-db2zos1:5000/genflow`) and then opened whatever URL the response returned in a new browser window via `window.open(r.url, '_blank')` -- without `noopener`/`noreferrer` and without any origin allow-listing.

Because the endpoint was plain HTTP, an adjacent MITM attacker (or anyone able to control/spoof that hostname) could return an arbitrary phishing URL that the editor would open in a new tab. The method was already unreachable -- no `internalName: 'graphicDiagram'` entry exists in `MENU` or `LANGUAGE_MENUS` -- so practical exploitability was nil, but the vulnerable code remained compiled into the shipped bundle.

Rather than patching the `window.open` call, this PR removes the dead code entirely, eliminating both the insecure sink and the untrusted HTTP endpoint from the codebase:

- Removed the `graphicDiagram()` method from menu-bar.component.ts.
- Removed the now-orphaned `diagram` field from the `Endpoints` interface in endpoints.ts.
- Removed the `diagram: 'http://wal-vm-db2zos1:5000/genflow'` value from environment.ts.
- Added a CHANGELOG entry.

(Note: the existing `window.open` call in monaco.component.ts already uses `'noopener,noreferrer'`, so no other call sites required remediation.)

CVSS 3.1 - 4.3 :: AV:A/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

Since this change removes dead code, testing focuses on confirming no regression:

1. Build the editor: `cd zlux-editor/webClient && npm run build` -- compiles cleanly with no new warnings.
2. Load the editor plugin in the Zowe desktop and confirm all existing menu-bar actions (open, save, save-as, submit job, settings, etc.) continue to function normally.
3. Confirm no menu item is missing -- `graphicDiagram()` had no menu entry, so the UI is unchanged.
4. Grep the source tree to confirm no remaining references to `diagram` / `graphicDiagram` remain.

## Further comments

The method was chosen for removal (rather than adding `noopener,noreferrer` and origin allow-listing) because it had no menu binding and no path to invocation, making it pure dead code. Removing it is the cleanest way to guarantee the vulnerable sink and the plaintext HTTP endpoint are not shipped in the bundle. If a diagram-generation feature is desired in the future, it should be reintroduced against an HTTPS endpoint with response-URL origin validation and `window.open(..., '_blank', 'noopener,noreferrer')`.