### PR TITLE
Fix unescaped USS path in app2app permalink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `3.6.0`
 
+- Bugfix: Fixed a JSON injection flaw in "Open in new tab" and "Copy permalink" where USS file/directory names containing `"` or `\` were concatenated directly into the launch payload string. Crafted names could override the `type`/`name`/`lines` keys and cause a different file or dataset to be opened than displayed. The payload is now built with `JSON.stringify`, which properly escapes special characters.
+
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## `3.6.0`
 
-- Bugfix: Fixed a JSON injection flaw in "Open in new tab" and "Copy permalink" where USS file/directory names containing `"` or `\` were concatenated directly into the launch payload string. Crafted names could override the `type`/`name`/`lines` keys and cause a different file or dataset to be opened than displayed. The payload is now built with `JSON.stringify`, which properly escapes special characters.
-
+- Bugfix: Fixed a JSON injection flaw in "Open in new tab" and "Copy permalink" where USS file/directory names containing `"` or `\` were concatenated directly into the launch payload string. Crafted names could override the `type`/`name`/`lines` keys and cause a different file or dataset to be opened than displayed. ([#396](https://github.com/zowe/zlux-editor/pull/396))
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
@@ -493,10 +493,10 @@ export class MonacoComponent implements OnInit, OnChanges {
     let link = '';
     if (activeFile.model.isDataset) {
       filePath = activeFile.model.path;
-      link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openDataset","name":"${filePath}","lines":"${lines}","toggleTree":true}`)}`;
+      link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(JSON.stringify({ type: 'openDataset', name: filePath, lines: `${lines}`, toggleTree: true }))}`;
     } else {
       filePath = activeFile.model.path + "/" + activeFile.model.name;
-      link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openFile","name":"${filePath}","lines":"${lines}","toggleTree":true}`)}`;
+      link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(JSON.stringify({ type: 'openFile', name: filePath, lines: `${lines}`, toggleTree: true }))}`;
     }
     navigator.clipboard.writeText(link).then(() => {
       this.log.debug("Permalink copied to clipboard");

--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -234,11 +234,11 @@ export class ProjectTreeComponent {
   onOpenInNewTab($event: any) {
     if ($event.data === 'File') {
       const baseURI = `${window.location.origin}${window.location.pathname}`;
-      const newWindow = window.open(`${baseURI}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openFile","name":"${$event.path}","toggleTree":true}`)}`, '_blank');
+      const newWindow = window.open(`${baseURI}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(JSON.stringify({ type: 'openFile', name: $event.path, toggleTree: true }))}`, '_blank');
       newWindow.focus();
     } else {
       const baseURI = `${window.location.origin}${window.location.pathname}`;
-      const newWindow = window.open(`${baseURI}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openDataset","name":"${$event.data.path}","toggleTree":true}`)}`, '_blank');
+      const newWindow = window.open(`${baseURI}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(JSON.stringify({ type: 'openDataset', name: $event.data.path, toggleTree: true }))}`, '_blank');
       newWindow.focus();
     }
   }


### PR DESCRIPTION
## Proposed changes

This PR fixes a JSON injection vulnerability in the zlux-editor "Open in new tab" and "Copy permalink" features. USS file and directory names may legally contain `"` and `\`. The affected code concatenated the path directly into a JSON string template before `encodeURIComponent`, so a file named e.g. `x","type":"openFile","name":"/etc/shadow` produced:

```
{"type":"openFile","name":"x","type":"openFile","name":"/etc/shadow",...}
```

Because JSON parsers honor the last duplicate key, `AppComponent.handleLaunchOrMessageObject` would receive attacker-controlled `type`/`name`/`lines` values. A user who clicked "Open in new tab" -- or opened a shared "Copy permalink" -- for such a file would silently launch a different file/dataset than the one displayed.

The fix replaces the manual JSON string-building with `JSON.stringify` on a proper object at all four call sites. `JSON.stringify` correctly escapes `"`, `\`, and other special characters, so a crafted file name can no longer break out of the `name` string or inject duplicate keys:

- project-tree.component.ts -- "Open in new tab" for USS files
- project-tree.component.ts -- "Open in new tab" for datasets
- monaco.component.ts (`copyPermalink`) -- datasets
- monaco.component.ts (`copyPermalink`) -- files

The generated payload is byte-for-byte identical for benign paths; only special-character escaping changed. `lines` is still serialized as a string to preserve the existing wire format. A CHANGELOG entry was added.

CVSS 3.1 - 4.6 :: AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:N

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

1. Build the editor: `cd zlux-editor/webClient && npm run build` -- compiles cleanly with no new warnings.
2. Create a USS file with a benign name (e.g. `/u/user/test.txt`), open it in the editor:
   - Right-click the file in the tree -> "Open in new tab" -> confirm the correct file opens in the new browser tab.
   - Use "Copy permalink", paste the URL into a new tab -> confirm the correct file and line are opened.
   - Repeat for a dataset/member to verify the `openDataset` path.
3. Create a USS file with a crafted name containing a double quote and injected keys, e.g. `x","type":"openFile","name":"/etc/shadow`:
   - Before the fix: "Open in new tab" / permalink would open `/etc/shadow`.
   - After the fix: the launched `name` is exactly the crafted file name (the injection characters are escaped), so the intended file is opened, not the injected target.
4. Confirm no other `encodeURIComponent(\`{...}\`)` string-concatenation sites remain (grep of the editor source returns none).

## Further comments

`JSON.stringify` was chosen over manual escaping because it is the canonical, safe way to serialize a structured payload and eliminates an entire class of injection bugs rather than patching individual characters. The change is minimal and preserves the existing URL/payload format for all legitimate paths, so no consumers of the launch payload need updating.