### PR TITLE
Remove call to unsafe lodash functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## `3.6.0`
 
-- Bugfix: Removed the module-load mutation of the shared lodash singleton's `_.templateSettings.interpolate` and the use of `_.template` (an eval-equivalent) in `UtilsService.formatUrl`. The global mutation silently changed template interpolation syntax for every other zLUX plugin sharing the same lodash instance.
+- Bugfix: Removed the module-load mutation of the shared lodash singleton's `_.templateSettings.interpolate` and the use of `_.template` (an eval-equivalent) in `UtilsService.formatUrl`. The global mutation silently changed template interpolation syntax for every other zLUX plugin sharing the same lodash instance. ([#397](https://github.com/zowe/zlux-editor/pull/397))
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## `3.6.0`
 
-- Bugfix: Removed the module-load mutation of the shared lodash singleton's `_.templateSettings.interpolate` and the use of `_.template` (an eval-equivalent) in `UtilsService.formatUrl`. The global mutation silently changed template interpolation syntax for every other zLUX plugin sharing the same lodash instance, and `_.template` blocked strict CSP without `unsafe-eval`. URL placeholder substitution is now done with a local, non-eval string replacement.
-
+- Bugfix: Removed the module-load mutation of the shared lodash singleton's `_.templateSettings.interpolate` and the use of `_.template` (an eval-equivalent) in `UtilsService.formatUrl`. The global mutation silently changed template interpolation syntax for every other zLUX plugin sharing the same lodash instance.
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `3.6.0`
 
+- Bugfix: Removed the module-load mutation of the shared lodash singleton's `_.templateSettings.interpolate` and the use of `_.template` (an eval-equivalent) in `UtilsService.formatUrl`. The global mutation silently changed template interpolation syntax for every other zLUX plugin sharing the same lodash instance, and `_.template` blocked strict CSP without `unsafe-eval`. URL placeholder substitution is now done with a local, non-eval string replacement.
+
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/webClient/src/app/shared/utils.service.ts
+++ b/webClient/src/app/shared/utils.service.ts
@@ -9,16 +9,19 @@
   Copyright Contributors to the Zowe Project.
 */
 import { Injectable } from '@angular/core';
-import * as _ from 'lodash';
 
-_.templateSettings.interpolate = /{([\s\S]+?)}/g;
 @Injectable()
 export class UtilsService {
   constructor() { }
 
   formatUrl(url: string, options?: any): string {
-    const compiled = _.template(url);
-    return compiled(options);
+    if (!options) {
+      return url;
+    }
+    return url.replace(/{([\s\S]+?)}/g, (match, key) => {
+      const value = options[key.trim()];
+      return value !== undefined ? String(value) : match;
+    });
   }
 
   getDatasetName(dirName) {


### PR DESCRIPTION
## Proposed changes

This PR removes a global side effect and an eval-equivalent code path from the zlux-editor `UtilsService`. At module load, utils.service.ts assigned `_.templateSettings.interpolate = /{([\s\S]+?)}/g` on the shared lodash singleton. Because every other zLUX desktop plugin imports the same lodash instance, this silently changed template-interpolation syntax to `{expr}` for all of them -- a cross-plugin side effect.

`formatUrl` then called `_.template(url)`, which compiles its first argument into a `Function` body (eval-equivalent). Any `{...}` content in the template string is executed as JavaScript. In the current call sites the template strings come from `ENDPOINTS` constants, so there is no direct attacker-controlled code path today, but:
- (a) the global mutation is a cross-plugin side effect,
- (b) the pattern blocks deployment of a strict CSP without `unsafe-eval`, and
- (c) lodash `_.template` has historically carried code-injection CVEs (e.g. CVE-2021-23337).

The fix replaces `_.template` and the global `_.templateSettings` mutation with a local, non-eval `String.prototype.replace` that substitutes `{key}` placeholders from the options object. This preserves the exact `{key}` interpolation syntax the `ENDPOINTS` constants rely on, removes the shared-lodash mutation, and eliminates the eval path (unblocking strict CSP). The now-unused `import * as _ from 'lodash'` was removed from that file, and a CHANGELOG entry was added.

CVSS 3.1 - 5.4 :: AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:L/A:L

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

1. Build the editor: `cd zlux-editor/webClient && npm run build` -- compiles cleanly with no new warnings.
2. Verify URL interpolation still works at both active call sites:
   - Open a project so the tree loads -- this exercises `formatUrl(ENDPOINTS.projectStructure, { name })` in project-tree.component.ts; confirm the project structure request is issued to the correct `.../projects/<name>` URL.
   - Run a content search -- this exercises `formatUrl(ENDPOINTS.searchInFile, { project, pattern })` in frame.component.ts; confirm the `pattern={pattern}` placeholder is substituted correctly in the request URL.
3. Cross-plugin check: with the editor loaded, confirm another desktop plugin that uses lodash `_.template` with its default `<%= %>` interpolation behaves normally (previously the editor's global mutation would have broken it).
4. Confirm the value substitution is not eval-based: a placeholder value containing characters like `}` or `${...}` is inserted literally into the URL rather than being executed.

## Further comments

A local string-replace was chosen over re-scoping lodash template options (e.g. per-call `interpolate`) because it fully removes the eval path and the shared-singleton dependency, which is what unblocks a strict CSP. The substitution keeps the existing `{key}` placeholder syntax, so no `ENDPOINTS` constants or other callers need to change. If additional templating needs arise later, they should use a non-eval mechanism to preserve CSP compatibility.