### PR TITLE
Remove dev endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## `3.6.0`
 
-- Bugfix: Removed internal development hostnames (`rs22:5000`, `wal-vm-db2zos1:5000`) and plain-HTTP schemes from the bundled `ENDPOINTS` constants. These absolute dev URLs were shipped in `main.js`, disclosing internal infrastructure and risking cleartext transmission if any of their (currently dead) call sites were wired up. The affected endpoints now use same-origin relative paths.
-
+- Bugfix: Removed internal development hostnames present in `ENDPOINTS` constants. The affected endpoints now use same-origin relative paths. ([#398](https://github.com/zowe/zlux-editor/pull/398))
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `3.6.0`
 
+- Bugfix: Removed internal development hostnames (`rs22:5000`, `wal-vm-db2zos1:5000`) and plain-HTTP schemes from the bundled `ENDPOINTS` constants. These absolute dev URLs were shipped in `main.js`, disclosing internal infrastructure and risking cleartext transmission if any of their (currently dead) call sites were wired up. The affected endpoints now use same-origin relative paths.
+
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/webClient/src/environments/environment.ts
+++ b/webClient/src/environments/environment.ts
@@ -20,18 +20,18 @@ export const environment = {
 };
 
 export const ENDPOINTS: Endpoints = {
-  projectStructure: 'http://rs22:5000/projects/{name}',
+  projectStructure: '/projects/{name}',
   jsonFile: './mock/jsonFile.json',
   xmlFile: './mock/xmlFile.json',
   asmFile: './mock/file.json',
   htmlFile: './mock/htmlFile.json',
   project: '../../com.rs.mvd.ide/web/mock/project.json',
-  projectFile: 'http://rs22:5000/datasets/{name}/members',
-  file: 'http://rs22:5000/datasets/{dataset}/members/{member}',
-  saveFile: 'http://rs22:5000/datasets/{dataset}/members/{member}',
-  searchInFile: 'http://rs22:5000/projects/GCE/search?pattern={pattern}',
-  diagram: 'http://wal-vm-db2zos1:5000/genflow',
-  jobs: 'http://rs22:5000/jobs'
+  projectFile: '/datasets/{name}/members',
+  file: '/datasets/{dataset}/members/{member}',
+  saveFile: '/datasets/{dataset}/members/{member}',
+  searchInFile: '/projects/GCE/search?pattern={pattern}',
+  diagram: '/genflow',
+  jobs: '/jobs'
 };
 
 /*


### PR DESCRIPTION
## Proposed changes

This PR removes internal development infrastructure details from the shipped zlux-editor bundle. environment.ts defined `ENDPOINTS` constants pointing at internal dev hosts over plain HTTP (`http://rs22:5000/...` and `http://wal-vm-db2zos1:5000/genflow`). Because no `environment.prod.ts` exists, these constants were compiled into the shipped main.js, which:
- disclosed internal infrastructure (hostnames/ports) to any user who downloads the plugin, and
- would enable SSRF-style targeting -- transmitting live JCL/source content to internal hosts in cleartext -- if any of the (currently dead) call sites (`graphicDiagram`, `submitJob`, `searchFileContent`, `openProject`, `projectStructure`) were ever wired up.

The fix converts the seven internal-hostname endpoints (`projectStructure`, `projectFile`, `file`, `saveFile`, `searchInFile`, `diagram`, `jobs`) to same-origin relative paths (e.g. `/projects/{name}`, `/jobs`, `/genflow`). This removes the internal hostname disclosure and the plain-HTTP scheme from the bundle. If any dead path is ever wired up, requests now target the zLUX server origin over the application's own HTTPS rather than an internal host. The mock `./mock/*` paths were left unchanged as they contain no infrastructure details.

Context: all real editor data operations (opening/saving files and datasets, metadata) already go through `ZoweZLUX.uriBroker`; the affected `ENDPOINTS` are legacy dev constants referenced only by dead/unwired code (confirmed by the absence of active `internalName` menu entries; only a commented-out `openProject` remains).

CVSS 3.1 - 5.3 :: AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

1. Build the editor: `cd zlux-editor/webClient && npm run build` -- compiles cleanly with no new warnings.
2. Verify the shipped bundle contains no internal hostnames:
   - `gzip -dc web/v3/main.js.gz | grep -c "rs22:5000"` returns `0`.
   - `grep -REn "rs22:5000|wal-vm-db2zos1" web/v3/*.gz` (decompressed) returns nothing.
   - Note: the build's `PostBuildCleanupPlugin` deletes the uncompressed main.js, so the shipped artifact is `main.js.gz`.
3. Confirm normal editor operation is unaffected: open USS files and datasets, save, and browse the file tree -- these use `ZoweZLUX.uriBroker` and are independent of the changed constants.
4. Source scan: `grep -REn "rs22:5000|wal-vm-db2zos1" src/` returns nothing.

## Further comments

Relative same-origin paths were chosen over deleting the endpoints/call sites so this change stays narrowly scoped to the reported issue (internal-hostname disclosure in environment.ts) and avoids overlapping with separate cleanups of the individual dead call sites. The placeholder `{key}` syntax is preserved, so no other callers require changes. A longer-term improvement would be to route these features (if revived) through `ZoweZLUX.uriBroker` like the rest of the editor, and to add an `environment.prod.ts` so dev-only constants can never leak into a production build.