### PR TITLE
Remove dead submitJcl function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## `3.6.0`
 
-- Bugfix: Removed the unreachable `submitJob()` method, which POSTed the entire active JCL buffer (including job-card credentials) to an internal `ENDPOINTS.jobs` endpoint. The method had no menu entry and was never wired into the shipped UI; the actual JCL submit feature uses the z/OSMF jobs API. The now-orphaned `jobs` endpoint was also removed.
-
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `3.6.0`
 
+- Bugfix: Removed the unreachable `submitJob()` method, which POSTed the entire active JCL buffer (including job-card credentials) to an internal `ENDPOINTS.jobs` endpoint. The method had no menu entry and was never wired into the shipped UI; the actual JCL submit feature uses the z/OSMF jobs API. The now-orphaned `jobs` endpoint was also removed.
+
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -664,41 +664,6 @@ export class MenuBarComponent implements OnInit, OnDestroy {
     this.snackBar.open(`A new window will open after the diagram generated.`, 'Close', { duration: MessageDuration.Long, panelClass: 'center' });
   }
 
-  submitJob() {
-    let file = this.editorControl.fetchActiveFile();
-    if (!file || (file.model.language !== 'jcl')) {
-      this.snackBar.open(`Please open a JCL file before you submit job.`, 'Close', { duration: MessageDuration.Long, panelClass: 'center' });
-    } this.http.post(ENDPOINTS.jobs, { contents: file.model.contents }).subscribe(r => {
-      let jobId = r.jobid;
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.name = 'copy';
-      input.value = jobId;
-      input.style.position = 'absolute';
-      input.style.left = '-9999px';
-      document.body.appendChild(input);
-      // open snack bar
-      let snackBarRef = this.snackBar.open(
-        `Please copy this job id (${jobId}) and check it in terminal.`,
-        'Copy',
-        {
-          duration: MessageDuration.ExtraLong, panelClass: 'center'
-        });
-      // get snack bar button
-      const button = document.getElementsByClassName('mat-simple-snackbar-action')[0];
-      button.addEventListener('click', () => {
-        input.select();
-        document.execCommand('copy');
-        document.body.removeChild(input);
-      });
-      snackBarRef.afterDismissed().subscribe(action => {
-        if (action.dismissedByAction) {
-          // do something
-        }
-      });
-    });
-  }
-
   setEditorLanguage(language: string) {
     let fileContext = this.editorControl.fetchActiveFile();
     this.editorControl.setHighlightingModeForBuffer(fileContext, language);

--- a/webClient/src/app/shared/model/endpoints.ts
+++ b/webClient/src/app/shared/model/endpoints.ts
@@ -20,7 +20,6 @@ export interface Endpoints {
     saveFile: string;
     searchInFile: string;
     diagram: string;
-    jobs: string;
 }
 
 /*

--- a/webClient/src/environments/environment.ts
+++ b/webClient/src/environments/environment.ts
@@ -30,8 +30,7 @@ export const ENDPOINTS: Endpoints = {
   file: 'http://rs22:5000/datasets/{dataset}/members/{member}',
   saveFile: 'http://rs22:5000/datasets/{dataset}/members/{member}',
   searchInFile: 'http://rs22:5000/projects/GCE/search?pattern={pattern}',
-  diagram: 'http://wal-vm-db2zos1:5000/genflow',
-  jobs: 'http://rs22:5000/jobs'
+  diagram: 'http://wal-vm-db2zos1:5000/genflow'
 };
 
 /*


### PR DESCRIPTION
## Proposed changes

This PR removes a dead, insecure code path from the zlux-editor menu bar. The `submitJob()` method in menu-bar.component.ts POSTed the entire active JCL buffer -- which can contain job-card credentials and source -- to `ENDPOINTS.jobs` (`http://rs22:5000/jobs`), an internal dev endpoint reached in cleartext over the LAN.

The method is dead code: no menu entry references `internalName: 'submitJob'` and there is no template binding, so it cannot be triggered in the shipped UI. However, it was still compiled into the distributed bundle and would leak job-card credentials/source over the network if ever wired up.

Rather than patching the endpoint, this PR removes the dead code entirely, consistent with the removal of the similarly unreachable `graphicDiagram()` method:

- Removed the `submitJob()` method from menu-bar.component.ts.
- Removed the now-orphaned `jobs` field from the `Endpoints` interface in endpoints.ts.
- Removed the `jobs: 'http://rs22:5000/jobs'` value from environment.ts.
- Added a CHANGELOG entry.

The actual JCL submit feature is unaffected: it is implemented via the z/OSMF jobs API (`/ibmzosmf/api/v1/zosmf/restjobs/jobs/` in menu-bar.config.ts), which is independent of the removed dead code and endpoint.

CVSS 3.1 - 2.6 :: AV:A/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

Since this change removes dead code, testing focuses on confirming no regression:

1. Build the editor: `cd zlux-editor/webClient && npm run build` -- compiles cleanly with no new warnings.
2. Load the editor plugin in the Zowe desktop and confirm all existing menu-bar actions (open, save, save-as, settings, etc.) continue to function normally -- no menu item is missing, since `submitJob()` had no menu entry.
3. Verify the real JCL submit path still works: open a JCL file and submit it via the submit menu, confirming it uses the z/OSMF jobs API and the submitted job appears in JES Explorer.
4. Grep the source tree to confirm no remaining references to `submitJob` or `ENDPOINTS.jobs`.

## Further comments

Removal (rather than re-pointing the endpoint) was chosen because the method has no menu binding or path to invocation -- it is pure dead code -- so deleting it is the cleanest way to guarantee the credential-leaking sink and the internal cleartext endpoint are not shipped in the bundle. If a non-z/OSMF submit path is ever needed again, it should be implemented against an HTTPS, same-origin endpoint routed through `ZoweZLUX.uriBroker` like the rest of the editor's data services.