### PR TITLE
Harden lsp config against unsecure websockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## `3.6.0`
 
-- Bugfix: Hardened the language server (LSP) configuration. The default connection domain now uses the encrypted `wss://` scheme instead of `ws://`, and `LanguageServerService.updateSettings()` now rejects any configured domain that does not use the secure `wss://` scheme. The LSP connection path itself remains disabled; this addresses residual risk from future re-enablement.
-
+- Bugfix: Hardened the language server (LSP) configuration to demand "wss://" urls rather than permitting "ws://". ([#400](https://github.com/zowe/zlux-editor/pull/400))
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `3.6.0`
 
+- Bugfix: Hardened the language server (LSP) configuration. The default connection domain now uses the encrypted `wss://` scheme instead of `ws://`, and `LanguageServerService.updateSettings()` now rejects any configured domain that does not use the secure `wss://` scheme. The LSP connection path itself remains disabled; this addresses residual risk from future re-enablement.
+
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/webClient/src/app/shared/language-server/language-server.service.ts
+++ b/webClient/src/app/shared/language-server/language-server.service.ts
@@ -15,7 +15,7 @@ import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 @Injectable()
 export class LanguageServerService {
 
-  config = { domain: 'ws://localhost:3000', endpoint: { hlasm: 'asmServer', json: 'jsonServer' } };
+  config = { domain: 'wss://localhost:3000', endpoint: { hlasm: 'asmServer', json: 'jsonServer' } };
   connections: { name: string, connection: MessageConnection }[] = [];
   enabled: boolean = true;
 
@@ -35,6 +35,16 @@ export class LanguageServerService {
     } else {
       try{
         var serverConfig = JSON.parse(langSettings.config);
+        let domainIsSecure = false;
+        try {
+          domainIsSecure = new URL(serverConfig.domain).protocol === 'wss:';
+        } catch(e) {
+          domainIsSecure = false;
+        }
+        if (!domainIsSecure) {
+          this.log.warn("Language server domain rejected: it must use the secure 'wss://' scheme");
+          return;
+        }
         this.config = serverConfig;
         this.enabled = langSettings.enable;
       }catch(e){


### PR DESCRIPTION
## Proposed changes

This PR hardens the zlux-editor language server (LSP) configuration against unencrypted WebSocket connections and unvalidated user input. In language-server.service.ts, the default LSP connection `config` used an unencrypted `ws://` scheme to a fixed port (`ws://localhost:3000`), and `updateSettings()` accepted an arbitrary user-supplied domain (via `JSON.parse`) with no scheme validation.

In v3 the entire connection path (`connectToLanguageServer`, `listenTo`, `createWebSocket`, `createLanguageClient`) is commented out in monaco.component.ts, so the default is currently unreachable; only the configuration object and `updateSettings()` remain live. Residual risk is therefore limited to future re-enablement -- which this PR addresses proactively:

- Changed the default connection domain from `ws://localhost:3000` to the encrypted `wss://localhost:3000`.
- Added scheme validation in `updateSettings()`: a user-supplied `config.domain` is now parsed as a URL and rejected (with a warning log, leaving the existing config unchanged) unless its protocol is `wss:`.
- Added a CHANGELOG entry.

The settings dialog (language-server.component.ts) derives its displayed default from `getSettings()`, so it now presents the secure `wss://` default; no hardcoded `ws://` remains anywhere in source.

CVSS 3.1 - 2.6 :: AV:A/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

1. Build the editor: `cd zlux-editor/webClient && npm run build` -- compiles cleanly with no new warnings.
2. Open the editor's Language Server settings dialog and confirm the displayed default domain is `wss://localhost:3000`.
3. Exercise `updateSettings()` validation:
   - Save a config whose `domain` is `wss://some-host:3000` -> accepted; `getSettings()` reflects the new value.
   - Save a config whose `domain` is `ws://some-host:3000` -> rejected; a warning is logged and the previous config is retained.
   - Save a config whose `domain` is a non-URL / missing scheme (e.g. `localhost:3000`) -> rejected and previous config retained.
4. Confirm no regression to editor functionality, since the LSP connection path remains disabled (commented out) and unaffected.

## Further comments

The scheme check is implemented inline in `updateSettings()` (rather than as a shared helper) since it is a single-use validation, consistent with the surrounding code style. `wss://` enforcement was chosen to match the reported concern about the unencrypted default; if plaintext loopback (`ws://localhost`) is ever required for local development when the LSP path is re-enabled, the validation can be revisited at that time. Re-enabling the LSP should also route the connection through the platform's secure transport rather than a fixed hardcoded port.