### PR TITLE
Eliminate the runtime eval in the menu bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `3.6.0`
 
+- Bugfix: Removed runtime `new Function(...)` compilation of menu-action strings. Menu `functionString`/`isDisabledString` entries in the menu config are now defined as real TypeScript functions, and the string-to-function conversion (`initMenu`/`initMenus`) was removed. This eliminates an `eval`-equivalent code path (which would have become stored-config code execution if menus were ever loaded from plugin config) and removes the `unsafe-eval` requirement for CSP.
+
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.
 - Enhancement: Session picker dialog on startup lets users choose which session to restore, create new sessions, or start empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## `3.6.0`
 
-- Bugfix: Removed runtime `new Function(...)` compilation of menu-action strings. Menu `functionString`/`isDisabledString` entries in the menu config are now defined as real TypeScript functions, and the string-to-function conversion (`initMenu`/`initMenus`) was removed. This eliminates an `eval`-equivalent code path (which would have become stored-config code execution if menus were ever loaded from plugin config) and removes the `unsafe-eval` requirement for CSP.
+- Bugfix: Removed runtime `new Function(...)` compilation of menu-action strings. Menu `functionString`/`isDisabledString` entries in the menu config are now defined as real TypeScript functions, and the string-to-function conversion (`initMenu`/`initMenus`) was removed. This eliminates an `eval`-equivalent code path (which would have become stored-config code execution if menus were ever loaded from plugin config) and removes the `unsafe-eval` requirement for CSP. ([#401](https://github.com/zowe/zlux-editor/pull/401))
 
 - Enhancement: Added element IDs to all UI components (dialogs, menu bar, tabs, nav, file explorer) for Selenium test automation.
 - Enhancement: Added editor session persistence with named sessions. Open tabs are saved to the Zowe config dataservice and restored when the editor is reopened.

--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -32,29 +32,6 @@ import { KeyCode } from '../../shared/keycode-enum';
 import * as _ from 'lodash';
 import { ProjectContext, ProjectContextType } from '../../shared/model/project-context';
 
-function initMenu(menuItems) {
-  menuItems.forEach(function (menuItem) {
-    if (menuItem.action && !menuItem.action.func && menuItem.action.functionString) {
-      menuItem.action.func = new Function('context', menuItem.action.functionString);
-    }
-    if (!menuItem.isDisabled && menuItem.isDisabledString) {
-      menuItem.isDisabled = new Function('context', menuItem.isDisabledString);
-    }
-  });
-  return menuItems;
-}
-function initMenus(menus) {
-  if (menus.isArray) {
-    return initMenu(menus);
-  } else {
-    const keys = (Object as any).keys(menus);
-    for (let i = 0; i < keys.length; i++) {
-      menus[keys[i]] = initMenu(menus[keys[i]]);
-    }
-    return menus;
-  }
-}
-
 // Where el is the DOM element you'd like to test for visibility
 function isHidden(el) {
   return (el.offsetParent === null)
@@ -116,7 +93,6 @@ export class MenuBarComponent implements OnInit, OnDestroy {
     this.addFileTreeMenus(this.menuList);
     this.addDiffViewerMenus(this.menuList);
     this.addToggleTreeMenus(this.menuList);
-    this.languagesMenu = initMenus(this.languagesMenu);
 
     this.editorControl.languageRegistered.subscribe((languageDefinition) => {
       this.resetLanguageSelectionMenu();

--- a/webClient/src/app/core/menu-bar/menu-bar.config.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.config.ts
@@ -12,34 +12,36 @@
 export const TEST_LANGUAGE_MENU = [{
   name: 'TEST_REPLACE',
   action: {
-    functionString: `
-                    console.log("My context=",context);
-                    context.editor.setValue("GOODBYE TEXT");`, params: []
+    func: (context: any) => {
+      console.log("My context=", context);
+      context.editor.setValue("GOODBYE TEXT");
+    }, params: []
   }, keyMap: ''
 },
 {
   name: 'Crop',
   action: {
-    functionString: `
-                    const selection = context.editor.cursor.getSelection();
-                    context.log.info('selection=',selection);
-                    if (selection) {
-                      context.editor.setValue(context.editor.getValueInRange(selection));
-                    }`, params: []
+    func: (context: any) => {
+      const selection = context.editor.cursor.getSelection();
+      context.log.info('selection=', selection);
+      if (selection) {
+        context.editor.setValue(context.editor.getValueInRange(selection));
+      }
+    }, params: []
   }, keyMap: ''
 },
 {
   name: 'Is Dataset?',
   action: {
-    functionString: `
-                    const model = context.controller.fetchActiveFile().model;
-                    context.log.info('My model=',model);
-                    const isDataset = model.isDataset;
-                    const fullName = isDataset ? model.fileName : model.name;
-                    context.controller.snackBar.open(isDataset ? fullName+' is a dataset!'
-                                                     : fullName+' is NOT a dataset.', 'Close',
-                                                     { duration: 3000, panelClass: 'center' });
-                    `, params: []
+    func: (context: any) => {
+      const model = context.controller.fetchActiveFile().model;
+      context.log.info('My model=', model);
+      const isDataset = model.isDataset;
+      const fullName = isDataset ? model.fileName : model.name;
+      context.controller.snackBar.open(isDataset ? fullName + ' is a dataset!'
+        : fullName + ' is NOT a dataset.', 'Close',
+        { duration: 3000, panelClass: 'center' });
+    }, params: []
   }, keyMap: ''
 }
 ]
@@ -48,14 +50,14 @@ export const LANGUAGE_MENUS = {
   'jcl': [
     {
       name: 'Submit',
-      isDisabledString: `
+      isDisabled: (context: any) => {
         const plugin = ZoweZLUX.pluginManager.getPlugin('org.zowe.explorer-jes');
         const file = context.controller.fetchActiveFile();
         if (!plugin || !file || (ZoweZLUX.uriBroker.serverRootUri('') == '/')) {
           return true;
         }
         return false;
-      `,
+      },
       action: {
         /*
           TODO z/osmf has a jobs api, so this makes use of it for now. 
@@ -67,50 +69,53 @@ export const LANGUAGE_MENUS = {
           but for dev, app-server only testing, prob need ZoweZLUX.uriBroker.serverRootUri('')
           note: rawStream handling below can be used to read ReadableStream for debugging
           */
-        functionString: `
-        const file = context.controller.fetchActiveFile();
-        const uri = '/ibmzosmf/api/v1/zosmf/restjobs/jobs/';
+        func: (context: any) => {
+          const file = context.controller.fetchActiveFile();
+          const uri = '/ibmzosmf/api/v1/zosmf/restjobs/jobs/';
 
-        if (file) {
-          let content = context.editor.getValue();
-          if (content && content.length > 0) {
-            fetch(uri, {method: 'PUT', body: content,
-                        credentials: 'include',
-                        mode: 'cors',
-                        headers:{ 
-                          "Content-Type": "text/plain", 
-                          "X-CSRF-ZOSMF-HEADER": "true",
-                          "Accept": "application/json" }})
-              .then(async (response) => {
-                    // const rawStream = await response.clone().text();
-                    // console.log("Response body?", rawStream)
-                     if (!response.ok) {
-                       throw new Error('Status: '+response.status+', '+response.statusText);
-                     } else {
-                       return response.json();
-                     }
+          if (file) {
+            let content = context.editor.getValue();
+            if (content && content.length > 0) {
+              fetch(uri, {
+                method: 'PUT', body: content,
+                credentials: 'include',
+                mode: 'cors',
+                headers: {
+                  "Content-Type": "text/plain",
+                  "X-CSRF-ZOSMF-HEADER": "true",
+                  "Accept": "application/json"
+                }
               })
-              .then((response)=> {
-                     if (response.jobid && response.owner) {
-                       file.model.jobid = response.jobid;
-                       file.model.jobOwner = response.owner;
-                       let ref = context.controller.snackBar.open('JCL Submitted. ID='+response.jobid,'View in Explorer', {duration: 5000, panelClass: 'center' })
-                         .onAction().subscribe(()=> {
-                           const dispatcher = ZoweZLUX.dispatcher;
-                           const argumentFormatter = {data: {op:'deref',source:'event',path:['data']}};
-                           let action = dispatcher.makeAction('org.zowe.editor.jcl.view', 'View JCL',
-                                                              dispatcher.constants.ActionTargetMode.PluginFindAnyOrCreate,
-                                                              dispatcher.constants.ActionType.Launch,'org.zowe.explorer-jes',argumentFormatter);
-                           dispatcher.invokeAction(action,{'data':{'owner':file.model.jobOwner,'prefix':'*','jobId':file.model.jobid}});
-                         });
-                     } else {
-                       context.controller.snackBar.open('Warning: JCL submitted but Job ID not found.', 'Dismiss', {duration: 5000, panelClass: 'center' });
-                     }
-                   })
-              .catch(error=> context.controller.snackBar.open('Error submitting JCL: '+error.message, 'Dismiss', {duration: 5000, panelClass: 'center' }));
+                .then(async (response) => {
+                  // const rawStream = await response.clone().text();
+                  // console.log("Response body?", rawStream)
+                  if (!response.ok) {
+                    throw new Error('Status: ' + response.status + ', ' + response.statusText);
+                  } else {
+                    return response.json();
+                  }
+                })
+                .then((response: any) => {
+                  if (response.jobid && response.owner) {
+                    file.model.jobid = response.jobid;
+                    file.model.jobOwner = response.owner;
+                    context.controller.snackBar.open('JCL Submitted. ID=' + response.jobid, 'View in Explorer', { duration: 5000, panelClass: 'center' })
+                      .onAction().subscribe(() => {
+                        const dispatcher = ZoweZLUX.dispatcher;
+                        const argumentFormatter = { data: { op: 'deref', source: 'event', path: ['data'] } };
+                        let action = dispatcher.makeAction('org.zowe.editor.jcl.view', 'View JCL',
+                          dispatcher.constants.ActionTargetMode.PluginFindAnyOrCreate,
+                          dispatcher.constants.ActionType.Launch, 'org.zowe.explorer-jes', argumentFormatter);
+                        dispatcher.invokeAction(action, { 'data': { 'owner': file.model.jobOwner, 'prefix': '*', 'jobId': file.model.jobid } });
+                      });
+                  } else {
+                    context.controller.snackBar.open('Warning: JCL submitted but Job ID not found.', 'Dismiss', { duration: 5000, panelClass: 'center' });
+                  }
+                })
+                .catch((error: any) => context.controller.snackBar.open('Error submitting JCL: ' + error.message, 'Dismiss', { duration: 5000, panelClass: 'center' }));
+            }
           }
-        }
-        `,
+        },
         params: []
       },
       keyMap: ''
@@ -120,29 +125,29 @@ export const LANGUAGE_MENUS = {
     },
     {
       name: 'View Job',
-      isDisabledString: `
-      const plugin = ZoweZLUX.pluginManager.getPlugin('org.zowe.explorer-jes');
-      const file = context.controller.fetchActiveFile();
-      if (plugin && file) {
-        return !file.model.jobid;
-      } else {
-        return true;
-      }
-      `,
-      action: {
-        functionString: `
+      isDisabled: (context: any) => {
+        const plugin = ZoweZLUX.pluginManager.getPlugin('org.zowe.explorer-jes');
         const file = context.controller.fetchActiveFile();
-        if (file) {
-          const dispatcher = ZoweZLUX.dispatcher;
-          const argumentFormatter = {data: {op:'deref',source:'event',path:['data']}};
-          let action = dispatcher.makeAction('org.zowe.editor.jcl.view', 'View JCL',
-                                             dispatcher.constants.ActionTargetMode.PluginFindAnyOrCreate,
-                                             dispatcher.constants.ActionType.Launch,'org.zowe.explorer-jes',argumentFormatter);
-          dispatcher.invokeAction(action,{'data':{'owner':file.model.jobOwner,'prefix':'*','jobid':file.model.jobid}});
+        if (plugin && file) {
+          return !file.model.jobid;
         } else {
-          context.controller.snackBar.open('Cannot find open file', 'Dismiss', {duration: 3000, panelClass: 'center' });
+          return true;
         }
-        `,
+      },
+      action: {
+        func: (context: any) => {
+          const file = context.controller.fetchActiveFile();
+          if (file) {
+            const dispatcher = ZoweZLUX.dispatcher;
+            const argumentFormatter = { data: { op: 'deref', source: 'event', path: ['data'] } };
+            let action = dispatcher.makeAction('org.zowe.editor.jcl.view', 'View JCL',
+              dispatcher.constants.ActionTargetMode.PluginFindAnyOrCreate,
+              dispatcher.constants.ActionType.Launch, 'org.zowe.explorer-jes', argumentFormatter);
+            dispatcher.invokeAction(action, { 'data': { 'owner': file.model.jobOwner, 'prefix': '*', 'jobid': file.model.jobid } });
+          } else {
+            context.controller.snackBar.open('Cannot find open file', 'Dismiss', { duration: 3000, panelClass: 'center' });
+          }
+        },
         params: []
       },
       keyMap: ''


### PR DESCRIPTION
## Proposed changes

This PR removes a runtime code-compilation (`eval`-equivalent) pattern from the zlux-editor menu bar. `initMenu()` in menu-bar.component.ts converted the `functionString` / `isDisabledString` properties of menu entries into live functions via `new Function('context', ...)`.

Today those strings are static literals in menu-bar.config.ts, so there is no untrusted source. However, the menu-bar constructor contains commented-out scaffolding to fetch `languages/menus` from `pluginConfigUri`; if that were ever enabled, the `new Function` pattern would turn stored plugin configuration into arbitrary code execution. The pattern also forces `unsafe-eval` in any Content Security Policy.

The fix defines the menu actions as real, statically-compiled TypeScript functions instead of strings, and removes the string-to-function conversion entirely:

- Converted every `functionString` / `isDisabledString` entry in menu-bar.config.ts (the `TEST_LANGUAGE_MENU` items and the `jcl` `Submit` / `View Job` items) into real `func` / `isDisabled` functions.
- Removed the `initMenu()` / `initMenus()` helpers, the two `new Function(...)` calls, and the `this.languagesMenu = initMenus(...)` call site.
- Added a CHANGELOG entry.

The menu action bodies are now compiled and type-checked at build time rather than assembled from strings at runtime, and `unsafe-eval` is no longer required for these menus. Existing callers are unchanged: `menuAction()` still invokes `action.func(context, ...params)` and `getMenuItemStyle()` still calls `isDisabled({editor, controller, log})`.

CVSS 3.1 - 3.0 :: AV:L/AC:H/PR:H/UI:N/S:U/C:L/I:L/A:N

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

1. Build the editor: `cd zlux-editor/webClient && npm run build` -- compiles cleanly with no new warnings. (The action bodies are now type-checked by the compiler for the first time.)
2. Open a JCL file and verify the language menu:
   - `Submit` is disabled when JES Explorer is not present / no file is open, and enabled otherwise; submitting a JCL shows the "JCL Submitted. ID=..." snackbar and the "View in Explorer" action launches JES Explorer.
   - `View Job` is disabled until a job has been submitted for the file, then launches the job view.
3. If running with test-language mode enabled, confirm the `TEST_LANGUAGE` menu items (`TEST_REPLACE`, `Crop`, `Is Dataset?`) still execute.
4. Grep to confirm no remaining `functionString`, `isDisabledString`, `new Function`, or `initMenu` references exist in source.

## Further comments

Defining the actions as real functions (rather than sanitizing the string input) is the robust fix: it removes the `eval` path outright, so no future re-enablement of config-sourced menus can introduce code execution, and it makes the menu logic type-checked and refactor-safe. One unused `let ref =` assignment in the Submit handler was dropped during the conversion. If dynamic, config-driven menus are desired later, they should be modeled as data (declarative action identifiers mapped to a fixed set of handlers) rather than executable code strings.