### PR TITLE
Replace lodash _.template eval and global templateSettings mutation w…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `2.18.6`
+
+- Bugfix: Removed the module-load mutation of the shared lodash singleton's `_.templateSettings.interpolate` and the use of `_.template` (an eval-equivalent) in `UtilsService.formatUrl`. The global mutation silently changed template interpolation syntax for every other zLUX plugin sharing the same lodash instance, and `_.template` blocked strict CSP without `unsafe-eval`. URL placeholder substitution is now done with a local, non-eval string replacement.
+
 ## `3.0.1`
  
 - Bugfix: Added a few rules for JCL syntax highlighter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## `2.18.6`
 
-- Bugfix: Removed the module-load mutation of the shared lodash singleton's `_.templateSettings.interpolate` and the use of `_.template` (an eval-equivalent) in `UtilsService.formatUrl`. The global mutation silently changed template interpolation syntax for every other zLUX plugin sharing the same lodash instance, and `_.template` blocked strict CSP without `unsafe-eval`. URL placeholder substitution is now done with a local, non-eval string replacement.
+- Bugfix: Removed the module-load mutation of the shared lodash singleton's `_.templateSettings.interpolate` and the use of `_.template` (an eval-equivalent) in `UtilsService.formatUrl`. The global mutation silently changed template interpolation syntax for every other zLUX plugin sharing the same lodash instance. ([#402](https://github.com/zowe/zlux-editor/pull/402))
 
 ## `3.0.1`
  

--- a/webClient/src/app/shared/utils.service.ts
+++ b/webClient/src/app/shared/utils.service.ts
@@ -9,16 +9,19 @@
   Copyright Contributors to the Zowe Project.
 */
 import { Injectable } from '@angular/core';
-import * as _ from 'lodash';
 
-_.templateSettings.interpolate = /{([\s\S]+?)}/g;
 @Injectable()
 export class UtilsService {
   constructor() { }
 
   formatUrl(url: string, options?: any): string {
-    const compiled = _.template(url);
-    return compiled(options);
+    if (!options) {
+      return url;
+    }
+    return url.replace(/{([\s\S]+?)}/g, (match, key) => {
+      const value = options[key.trim()];
+      return value !== undefined ? String(value) : match;
+    });
   }
 
   getDatasetName(dirName) {


### PR DESCRIPTION
Proposed changes
Removes the module-load mutation [_.templateSettings.interpolate = /{...}/g](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on the shared lodash singleton (which silently changed interpolation for every other plugin) and the [_.template](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) eval in [UtilsService.formatUrl](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). Placeholder substitution now uses a local, non-eval [String.replace](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), preserving the {key} syntax the [ENDPOINTS](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) constants use; the now-unused lodash import was removed.

CVSS 3.1 - 5.4 :: AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:L/A:L

Type of change
 Bug fix (non-breaking change which fixes an issue)
PR Checklist
 This PR targets the "staging" branch (v2.x/staging).
 Relevant update to [CHANGELOG.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 My changes generate no new warnings
Testing
Open a project (uses [projectStructure](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) and run a content search (uses [searchInFile](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)); confirm placeholders substitute correctly. Confirm another plugin's default lodash [_.template](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (<%= %>) behaves normally.