### PR TITLE
Remove internal dev hostnames from bundled ENDPOINTS constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## `2.18.6`
 
-- Bugfix: Removed internal development hostnames (`rs22:5000`, `wal-vm-db2zos1:5000`) and plain-HTTP schemes from the bundled `ENDPOINTS` constants. These absolute dev URLs were shipped in `main.js`, disclosing internal infrastructure and risking cleartext transmission if any of their (currently dead) call sites were wired up. The affected endpoints now use same-origin relative paths.
+
+- Bugfix: Removed internal development hostnames present in `ENDPOINTS` constants. The affected endpoints now use same-origin relative paths. ([#403](https://github.com/zowe/zlux-editor/pull/403))
 
 ## `3.0.1`
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `2.18.6`
+
+- Bugfix: Removed internal development hostnames (`rs22:5000`, `wal-vm-db2zos1:5000`) and plain-HTTP schemes from the bundled `ENDPOINTS` constants. These absolute dev URLs were shipped in `main.js`, disclosing internal infrastructure and risking cleartext transmission if any of their (currently dead) call sites were wired up. The affected endpoints now use same-origin relative paths.
+
 ## `3.0.1`
  
 - Bugfix: Added a few rules for JCL syntax highlighter

--- a/webClient/src/environments/environment.ts
+++ b/webClient/src/environments/environment.ts
@@ -20,18 +20,18 @@ export const environment = {
 };
 
 export const ENDPOINTS: Endpoints = {
-  projectStructure: 'http://rs22:5000/projects/{name}',
+  projectStructure: '/projects/{name}',
   jsonFile: './mock/jsonFile.json',
   xmlFile: './mock/xmlFile.json',
   asmFile: './mock/file.json',
   htmlFile: './mock/htmlFile.json',
   project: '../../com.rs.mvd.ide/web/mock/project.json',
-  projectFile: 'http://rs22:5000/datasets/{name}/members',
-  file: 'http://rs22:5000/datasets/{dataset}/members/{member}',
-  saveFile: 'http://rs22:5000/datasets/{dataset}/members/{member}',
-  searchInFile: 'http://rs22:5000/projects/GCE/search?pattern={pattern}',
-  diagram: 'http://wal-vm-db2zos1:5000/genflow',
-  jobs: 'http://rs22:5000/jobs'
+  projectFile: '/datasets/{name}/members',
+  file: '/datasets/{dataset}/members/{member}',
+  saveFile: '/datasets/{dataset}/members/{member}',
+  searchInFile: '/projects/GCE/search?pattern={pattern}',
+  diagram: '/genflow',
+  jobs: '/jobs'
 };
 
 /*


### PR DESCRIPTION
Proposed changes
Removes internal dev hostnames (rs22:5000, wal-vm-db2zos1:5000) and plain-HTTP schemes from the bundled [ENDPOINTS](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). These absolute dev URLs were compiled into [main.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), disclosing internal infrastructure and risking cleartext transmission if any (currently dead) call site were wired up. The seven hostname endpoints now use same-origin relative paths; real editor I/O already uses [ZoweZLUX.uriBroker](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

CVSS 3.1 - 5.3 :: AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N

Type of change
 Bug fix (non-breaking change which fixes an issue)
PR Checklist
 This PR targets the "staging" branch (v2.x/staging).
 Relevant update to [CHANGELOG.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 My changes generate no new warnings
Testing
Grep src/ for rs22:5000/wal-vm-db2zos1 -> none. Confirm normal editor open/save/browse (uses [uriBroker](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) is unaffected.