### PR TITLE
Remove dead submitJob method and orphaned jobs endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Zlux Editor Changelog
 
-## `2.18.6`
-
-- Bugfix: Removed the unreachable `submitJob()` method, which POSTed the entire active JCL buffer (including job-card credentials) to an internal `ENDPOINTS.jobs` endpoint. The method had no menu entry and was never wired into the shipped UI. The now-orphaned `jobs` endpoint was also removed.
-
 ## `3.0.1`
  
 - Bugfix: Added a few rules for JCL syntax highlighter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `2.18.6`
+
+- Bugfix: Removed the unreachable `submitJob()` method, which POSTed the entire active JCL buffer (including job-card credentials) to an internal `ENDPOINTS.jobs` endpoint. The method had no menu entry and was never wired into the shipped UI. The now-orphaned `jobs` endpoint was also removed.
+
 ## `3.0.1`
  
 - Bugfix: Added a few rules for JCL syntax highlighter

--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -660,41 +660,6 @@ export class MenuBarComponent implements OnInit, OnDestroy {
     this.snackBar.open(`A new window will open after the diagram generated.`, 'Close', { duration: MessageDuration.Long, panelClass: 'center' });
   }
 
-  submitJob() {
-    let file = this.editorControl.fetchActiveFile();
-    if (!file || (file.model.language !== 'jcl')) {
-      this.snackBar.open(`Please open a JCL file before you submit job.`, 'Close', { duration: MessageDuration.Long, panelClass: 'center' });
-    } this.http.post(ENDPOINTS.jobs, { contents: file.model.contents }).subscribe(r => {
-      let jobId = r.jobid;
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.name = 'copy';
-      input.value = jobId;
-      input.style.position = 'absolute';
-      input.style.left = '-9999px';
-      document.body.appendChild(input);
-      // open snack bar
-      let snackBarRef = this.snackBar.open(
-        `Please copy this job id (${jobId}) and check it in terminal.`,
-        'Copy',
-        {
-          duration: MessageDuration.ExtraLong, panelClass: 'center'
-        });
-      // get snack bar button
-      const button = document.getElementsByClassName('mat-simple-snackbar-action')[0];
-      button.addEventListener('click', () => {
-        input.select();
-        document.execCommand('copy');
-        document.body.removeChild(input);
-      });
-      snackBarRef.afterDismissed().subscribe(action => {
-        if (action.dismissedByAction) {
-          // do something
-        }
-      });
-    });
-  }
-
   setEditorLanguage(language: string) {
     let fileContext = this.editorControl.fetchActiveFile();
     this.editorControl.setHighlightingModeForBuffer(fileContext, language);

--- a/webClient/src/app/shared/model/endpoints.ts
+++ b/webClient/src/app/shared/model/endpoints.ts
@@ -20,7 +20,6 @@ export interface Endpoints {
     saveFile: string;
     searchInFile: string;
     diagram: string;
-    jobs: string;
 }
 
 /*

--- a/webClient/src/environments/environment.ts
+++ b/webClient/src/environments/environment.ts
@@ -30,8 +30,7 @@ export const ENDPOINTS: Endpoints = {
   file: 'http://rs22:5000/datasets/{dataset}/members/{member}',
   saveFile: 'http://rs22:5000/datasets/{dataset}/members/{member}',
   searchInFile: 'http://rs22:5000/projects/GCE/search?pattern={pattern}',
-  diagram: 'http://wal-vm-db2zos1:5000/genflow',
-  jobs: 'http://rs22:5000/jobs'
+  diagram: 'http://wal-vm-db2zos1:5000/genflow'
 };
 
 /*


### PR DESCRIPTION
Proposed changes
Removes the unreachable [submitJob()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) method, which POSTed the entire active JCL buffer (potentially including job-card credentials) to the internal [ENDPOINTS.jobs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) endpoint in cleartext. It had no menu entry and could not be triggered in the shipped UI. Removed the method and the orphaned [jobs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) endpoint (interface + [environment.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)).

CVSS 3.1 - 2.6 :: AV:A/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N

Type of change
 Bug fix (non-breaking change which fixes an issue)
PR Checklist
 This PR targets the "staging" branch (v2.x/staging).
 Relevant update to [CHANGELOG.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 My changes generate no new warnings
Testing
Load the editor; confirm existing menu actions work and no menu item is missing. Grep confirms no remaining [submitJob](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[ENDPOINTS.jobs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) references.