### PR TITLE
Harden LSP config: default to wss and validate domain scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## `2.18.6`
 
-- Bugfix: Hardened the language server (LSP) configuration. The default connection domain now uses the encrypted `wss://` scheme instead of `ws://`, and `LanguageServerService.updateSettings()` now rejects any configured domain that does not use the secure `wss://` scheme. The LSP connection path itself remains disabled; this addresses residual risk from future re-enablement.
+- Bugfix: Hardened the language server (LSP) configuration to demand "wss://" urls rather than permitting "ws://". ([#405](https://github.com/zowe/zlux-editor/pull/405))
 
 ## `3.0.1`
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `2.18.6`
+
+- Bugfix: Hardened the language server (LSP) configuration. The default connection domain now uses the encrypted `wss://` scheme instead of `ws://`, and `LanguageServerService.updateSettings()` now rejects any configured domain that does not use the secure `wss://` scheme. The LSP connection path itself remains disabled; this addresses residual risk from future re-enablement.
+
 ## `3.0.1`
  
 - Bugfix: Added a few rules for JCL syntax highlighter

--- a/webClient/src/app/shared/language-server/language-server.service.ts
+++ b/webClient/src/app/shared/language-server/language-server.service.ts
@@ -15,7 +15,7 @@ import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 @Injectable()
 export class LanguageServerService {
 
-  config = { domain: 'ws://localhost:3000', endpoint: { hlasm: 'asmServer', json: 'jsonServer' } };
+  config = { domain: 'wss://localhost:3000', endpoint: { hlasm: 'asmServer', json: 'jsonServer' } };
   connections: { name: string, connection: MessageConnection }[] = [];
   enabled: boolean = true;
 
@@ -35,6 +35,16 @@ export class LanguageServerService {
     } else {
       try{
         var serverConfig = JSON.parse(langSettings.config);
+        let domainIsSecure = false;
+        try {
+          domainIsSecure = new URL(serverConfig.domain).protocol === 'wss:';
+        } catch(e) {
+          domainIsSecure = false;
+        }
+        if (!domainIsSecure) {
+          this.log.warn("Language server domain rejected: it must use the secure 'wss://' scheme");
+          return;
+        }
         this.config = serverConfig;
         this.enabled = langSettings.enable;
       }catch(e){


### PR DESCRIPTION
Proposed changes
Hardens the LSP config in [language-server.service.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): default domain changed from ws://localhost:3000 to encrypted wss://localhost:3000, and [updateSettings()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now rejects any user-supplied domain that isn't wss://. The LSP connection path remains disabled; this addresses residual risk from future re-enablement and removes the plaintext default.

CVSS 3.1 - 2.6 :: AV:A/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N

Type of change
 Bug fix (non-breaking change which fixes an issue)
PR Checklist
 This PR targets the "staging" branch (v2.x/staging).
 Relevant update to [CHANGELOG.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 My changes generate no new warnings
Testing
Open the Language Server settings dialog -> default shows wss://. Saving a wss:// domain is accepted; ws:// or a non-URL domain is rejected and the prior config retained.