### PR TITLE
Replace menu new Function eval with statically-defined action functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `2.18.6`
+
+- Bugfix: Removed runtime `new Function(...)` compilation of menu-action strings. Menu `functionString`/`isDisabledString` entries in the menu config are now defined as real TypeScript functions, and the string-to-function conversion (`initMenu`/`initMenus`) was removed. This eliminates an `eval`-equivalent code path (which would have become stored-config code execution if menus were ever loaded from plugin config) and removes the `unsafe-eval` requirement for CSP.
+
 ## `3.0.1`
  
 - Bugfix: Added a few rules for JCL syntax highlighter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## `2.18.6`
 
-- Bugfix: Removed runtime `new Function(...)` compilation of menu-action strings. Menu `functionString`/`isDisabledString` entries in the menu config are now defined as real TypeScript functions, and the string-to-function conversion (`initMenu`/`initMenus`) was removed. This eliminates an `eval`-equivalent code path (which would have become stored-config code execution if menus were ever loaded from plugin config) and removes the `unsafe-eval` requirement for CSP.
+- Bugfix: Changed initialization of menu action and disabled functions. Now, functions are used as opposed to strings that were evaluated into functions. ([#406](https://github.com/zowe/zlux-editor/pull/406))
 
 ## `3.0.1`
  

--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -32,29 +32,6 @@ import { KeyCode } from '../../shared/keycode-enum';
 import * as _ from 'lodash';
 import { ProjectContext, ProjectContextType } from '../../shared/model/project-context';
 
-function initMenu(menuItems) {
-  menuItems.forEach(function(menuItem) {
-    if (menuItem.action && !menuItem.action.func && menuItem.action.functionString) {
-      menuItem.action.func = new Function('context', menuItem.action.functionString);
-    }
-    if (!menuItem.isDisabled && menuItem.isDisabledString) {
-      menuItem.isDisabled = new Function('context', menuItem.isDisabledString);
-    }
-  });
-  return menuItems;
-}
-function initMenus(menus) {
-  if (menus.isArray) {
-    return initMenu(menus);
-  } else {
-    const keys = (Object as any).keys(menus);
-    for (let i = 0; i < keys.length; i++){
-      menus[keys[i]] = initMenu(menus[keys[i]]);
-    }
-    return menus;
-  }
-}
-
 // Where el is the DOM element you'd like to test for visibility
 function isHidden(el) {
   return (el.offsetParent === null)
@@ -116,7 +93,6 @@ export class MenuBarComponent implements OnInit, OnDestroy {
     this.addFileTreeMenus(this.menuList);
     this.addDiffViewerMenus(this.menuList);
     this.addToggleTreeMenus(this.menuList);
-    this.languagesMenu = initMenus(this.languagesMenu);
 
     this.editorControl.languageRegistered.subscribe((languageDefinition)=> {
       this.resetLanguageSelectionMenu();

--- a/webClient/src/app/core/menu-bar/menu-bar.config.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.config.ts
@@ -11,88 +11,92 @@
 
 export const TEST_LANGUAGE_MENU = [{name:'TEST_REPLACE',
                   action: {
-                    functionString:`
-                    console.log("My context=",context);
-                    context.editor.model.setValue("GOODBYE TEXT");`, params:[]}, keyMap: ''},
+                    func: (context: any) => {
+                      console.log("My context=", context);
+                      context.editor.model.setValue("GOODBYE TEXT");
+                    }, params:[]}, keyMap: ''},
                  {name:'Crop',
                   action: {
-                    functionString:`
-                    const selection = context.editor.cursor.getSelection();
-                    context.log.info('selection=',selection);
-                    if (selection) {
-                      context.editor.model.setValue(context.editor.model.getValueInRange(selection));
-                    }`, params:[]}, keyMap: ''},
+                    func: (context: any) => {
+                      const selection = context.editor.cursor.getSelection();
+                      context.log.info('selection=', selection);
+                      if (selection) {
+                        context.editor.model.setValue(context.editor.model.getValueInRange(selection));
+                      }
+                    }, params:[]}, keyMap: ''},
                  {name:'Is Dataset?',
                   action: {
-                    functionString:`
-                    const model = context.controller.fetchActiveFile().model;
-                    context.log.info('My model=',model);
-                    const isDataset = model.isDataset;
-                    const fullName = isDataset ? model.fileName : model.name;
-                    context.controller.snackBar.open(isDataset ? fullName+' is a dataset!'
-                                                     : fullName+' is NOT a dataset.', 'Close',
-                                                     { duration: 3000, panelClass: 'center' });
-                    `, params:[]}, keyMap: ''}
+                    func: (context: any) => {
+                      const model = context.controller.fetchActiveFile().model;
+                      context.log.info('My model=', model);
+                      const isDataset = model.isDataset;
+                      const fullName = isDataset ? model.fileName : model.name;
+                      context.controller.snackBar.open(isDataset ? fullName+' is a dataset!'
+                                                       : fullName+' is NOT a dataset.', 'Close',
+                                                       { duration: 3000, panelClass: 'center' });
+                    }, params:[]}, keyMap: ''}
                 ]
 
 export const LANGUAGE_MENUS = {
   'jcl': [
     {
       name: 'Submit (Future)',
-      isDisabledString: `
-      const plugin = ZoweZLUX.pluginManager.getPlugin('org.zowe.explorer-jes');
-      const file = context.controller.fetchActiveFile();
-    if (!plugin || !file || (ZoweZLUX.uriBroker.serverRootUri('') == '/')) {
+      isDisabled: (context: any) => {
+        const plugin = ZoweZLUX.pluginManager.getPlugin('org.zowe.explorer-jes');
+        const file = context.controller.fetchActiveFile();
+        if (!plugin || !file || (ZoweZLUX.uriBroker.serverRootUri('') == '/')) {
+          return true;
+        }
         return true;
-      }
-      return true;
-      ` /* CHANGEME TODO line above this comment should be "return false" once JCL submit works as intended */,
+      } /* CHANGEME TODO line above this comment should be "return false" once JCL submit works as intended */,
       action: {
         /*
           TODO z/osmf has a jobs api, so this makes use of it for now. 
           But, we don't import that service into the editor, because it would make a hard requirement instead of an optional one.
           May want to have such metadata in plugindef, or perhaps this is an interface & capability to be searched up
         */
-        functionString:`
-        const file = context.controller.fetchActiveFile();
-        if (file) {
-          let content = context.editor.model.getValue();
-          if (content && content.length > 0) {
-            content = content.replace(/\\n/g,'\\\\n');
-            const uri = '/api/v1/jobs/string';
-            const stringJsonBody = '{ "jcl": "'+content+'"}';  
-            fetch(uri, {method: 'POST', body: stringJsonBody,
-                        credentials: 'include',
-                        mode: 'cors',
-                        headers:{ 'Content-Type': 'application/json'}})
-              .then((response)=> {
-                     if (!response.ok) {
-                       throw new Error('Status: '+response.status+', '+response.statusText);
-                     } else {
-                       return response.json();
-                     }
-                   })
-              .then((response)=> {
-                     if (response.jobId && response.owner) {
-                       file.model.jobId = response.jobId;
-                       file.model.jobOwner = response.owner;
-                       let ref = context.controller.snackBar.open('JCL Submitted. ID='+response.jobId,'View in Explorer', {duration: 5000, panelClass: 'center' })
-                         .onAction().subscribe(()=> {
-                           const dispatcher = ZoweZLUX.dispatcher;
-                           const argumentFormatter = {data: {op:'deref',source:'event',path:['data']}};
-                           let action = dispatcher.makeAction('org.zowe.editor.jcl.view', 'View JCL',
-                                                              dispatcher.constants.ActionTargetMode.PluginFindAnyOrCreate,
-                                                              dispatcher.constants.ActionType.Launch,'org.zowe.explorer-jes',argumentFormatter);
-                           dispatcher.invokeAction(action,{'data':{'owner':file.model.jobOwner,'prefix':'*','jobId':file.model.jobId}});
-                         });
-                     } else {
-                       context.controller.snackBar.open('Warning: JCL submitted but Job ID not found.', 'Dismiss', {duration: 5000, panelClass: 'center' });
-                     }
-                   })
-              .catch(error=> context.controller.snackBar.open('Error submitting JCL: '+error.message, 'Dismiss', {duration: 5000, panelClass: 'center' }));
+        func: (context: any) => {
+          const file = context.controller.fetchActiveFile();
+          if (file) {
+            let content = context.editor.model.getValue();
+            if (content && content.length > 0) {
+              content = content.replace(/\n/g, '\\n');
+              const uri = '/api/v1/jobs/string';
+              const stringJsonBody = '{ "jcl": "' + content + '"}';
+              fetch(uri, {
+                method: 'POST', body: stringJsonBody,
+                credentials: 'include',
+                mode: 'cors',
+                headers: { 'Content-Type': 'application/json' }
+              })
+                .then((response) => {
+                  if (!response.ok) {
+                    throw new Error('Status: ' + response.status + ', ' + response.statusText);
+                  } else {
+                    return response.json();
+                  }
+                })
+                .then((response: any) => {
+                  if (response.jobId && response.owner) {
+                    file.model.jobId = response.jobId;
+                    file.model.jobOwner = response.owner;
+                    context.controller.snackBar.open('JCL Submitted. ID=' + response.jobId, 'View in Explorer', { duration: 5000, panelClass: 'center' })
+                      .onAction().subscribe(() => {
+                        const dispatcher = ZoweZLUX.dispatcher;
+                        const argumentFormatter = { data: { op: 'deref', source: 'event', path: ['data'] } };
+                        let action = dispatcher.makeAction('org.zowe.editor.jcl.view', 'View JCL',
+                          dispatcher.constants.ActionTargetMode.PluginFindAnyOrCreate,
+                          dispatcher.constants.ActionType.Launch, 'org.zowe.explorer-jes', argumentFormatter);
+                        dispatcher.invokeAction(action, { 'data': { 'owner': file.model.jobOwner, 'prefix': '*', 'jobId': file.model.jobId } });
+                      });
+                  } else {
+                    context.controller.snackBar.open('Warning: JCL submitted but Job ID not found.', 'Dismiss', { duration: 5000, panelClass: 'center' });
+                  }
+                })
+                .catch((error: any) => context.controller.snackBar.open('Error submitting JCL: ' + error.message, 'Dismiss', { duration: 5000, panelClass: 'center' }));
+            }
           }
-        }
-        `,
+        },
         params: []
       },
       keyMap: ''
@@ -102,29 +106,29 @@ export const LANGUAGE_MENUS = {
     },
     {
       name: 'View Job (Future)',
-      isDisabledString: `
-      const plugin = ZoweZLUX.pluginManager.getPlugin('org.zowe.explorer-jes');
-      const file = context.controller.fetchActiveFile();
-      if (plugin && file) {
-        return !file.model.jobId;
-      } else {
-        return true;
-      }
-      `,
-      action: {
-        functionString:`
+      isDisabled: (context: any) => {
+        const plugin = ZoweZLUX.pluginManager.getPlugin('org.zowe.explorer-jes');
         const file = context.controller.fetchActiveFile();
-        if (file) {
-          const dispatcher = ZoweZLUX.dispatcher;
-          const argumentFormatter = {data: {op:'deref',source:'event',path:['data']}};
-          let action = dispatcher.makeAction('org.zowe.editor.jcl.view', 'View JCL',
-                                             dispatcher.constants.ActionTargetMode.PluginFindAnyOrCreate,
-                                             dispatcher.constants.ActionType.Launch,'org.zowe.explorer-jes',argumentFormatter);
-          dispatcher.invokeAction(action,{'data':{'owner':file.model.jobOwner,'prefix':'*','jobId':file.model.jobId}});
+        if (plugin && file) {
+          return !file.model.jobId;
         } else {
-          context.controller.snackBar.open('Cannot find open file', 'Dismiss', {duration: 3000, panelClass: 'center' });
+          return true;
         }
-        `,
+      },
+      action: {
+        func: (context: any) => {
+          const file = context.controller.fetchActiveFile();
+          if (file) {
+            const dispatcher = ZoweZLUX.dispatcher;
+            const argumentFormatter = { data: { op: 'deref', source: 'event', path: ['data'] } };
+            let action = dispatcher.makeAction('org.zowe.editor.jcl.view', 'View JCL',
+              dispatcher.constants.ActionTargetMode.PluginFindAnyOrCreate,
+              dispatcher.constants.ActionType.Launch, 'org.zowe.explorer-jes', argumentFormatter);
+            dispatcher.invokeAction(action, { 'data': { 'owner': file.model.jobOwner, 'prefix': '*', 'jobId': file.model.jobId } });
+          } else {
+            context.controller.snackBar.open('Cannot find open file', 'Dismiss', { duration: 3000, panelClass: 'center' });
+          }
+        },
         params:[]
       },
       keyMap: ''


### PR DESCRIPTION
Proposed changes
Removes runtime [new Function('context', ...)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) compilation of menu-action strings. functionString/isDisabledString config entries (the [TEST_LANGUAGE_MENU](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) items and the jcl Submit (Future) / View Job (Future) items) are now real TypeScript functions, and the initMenu/initMenus conversion plus its call site were removed. This eliminates an eval-equivalent path (which would have become stored-config code execution if menus were ever loaded from pluginConfigUri) and removes the unsafe-eval CSP requirement.

CVSS 3.1 - 3.0 :: AV:L/AC:H/PR:H/UI:N/S:U/C:L/I:L/A:N

Type of change
 Bug fix (non-breaking change which fixes an issue)
PR Checklist
 This PR targets the "staging" branch (v2.x/staging).
 Relevant update to [CHANGELOG.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 My changes generate no new warnings
Testing
With a JCL file open, confirm the Submit (Future)/View Job (Future) items behave as before (Submit stays disabled per the existing return true). In test-language mode, confirm TEST_REPLACE/Crop/Is Dataset? still execute. Grep confirms no remaining functionString/isDisabledString/new Function/initMenu.