### PR TITLE
Remove dead graphicDiagram menu action and orphaned diagram endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Zlux Editor Changelog
 
-## `2.18.6`
-
-- Bugfix: Removed the unreachable `graphicDiagram()` menu action, which opened a URL returned by a remote HTTP endpoint in a new browser window without `noopener`/`noreferrer` or origin allow-listing. The method had no menu entry and is no longer compiled into the bundle.
-
 ## `3.0.1`
  
 - Bugfix: Added a few rules for JCL syntax highlighter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `2.18.6`
+
+- Bugfix: Removed the unreachable `graphicDiagram()` menu action, which opened a URL returned by a remote HTTP endpoint in a new browser window without `noopener`/`noreferrer` or origin allow-listing. The method had no menu entry and is no longer compiled into the bundle.
+
 ## `3.0.1`
  
 - Bugfix: Added a few rules for JCL syntax highlighter

--- a/webClient/src/app/core/menu-bar/menu-bar.component.ts
+++ b/webClient/src/app/core/menu-bar/menu-bar.component.ts
@@ -649,17 +649,6 @@ export class MenuBarComponent implements OnInit, OnDestroy {
     return `${item.name}`;
   }
 
-  graphicDiagram() {
-    let file = this.editorControl.fetchActiveFile();
-    if (!file) {
-      this.snackBar.open(`Please open a file before you generate a diagram.`, 'Close', { duration: MessageDuration.Long, panelClass: 'center' });
-    }
-    this.http.post(ENDPOINTS.diagram, { member: file.name, content: file.model.contents }).subscribe(r => {
-      window.open(r.url, '_blank');
-    });
-    this.snackBar.open(`A new window will open after the diagram generated.`, 'Close', { duration: MessageDuration.Long, panelClass: 'center' });
-  }
-
   submitJob() {
     let file = this.editorControl.fetchActiveFile();
     if (!file || (file.model.language !== 'jcl')) {

--- a/webClient/src/app/shared/model/endpoints.ts
+++ b/webClient/src/app/shared/model/endpoints.ts
@@ -19,7 +19,6 @@ export interface Endpoints {
     file: string;
     saveFile: string;
     searchInFile: string;
-    diagram: string;
     jobs: string;
 }
 

--- a/webClient/src/environments/environment.ts
+++ b/webClient/src/environments/environment.ts
@@ -30,7 +30,6 @@ export const ENDPOINTS: Endpoints = {
   file: 'http://rs22:5000/datasets/{dataset}/members/{member}',
   saveFile: 'http://rs22:5000/datasets/{dataset}/members/{member}',
   searchInFile: 'http://rs22:5000/projects/GCE/search?pattern={pattern}',
-  diagram: 'http://wal-vm-db2zos1:5000/genflow',
   jobs: 'http://rs22:5000/jobs'
 };
 


### PR DESCRIPTION
Proposed changes
Removes the unreachable [graphicDiagram()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) menu action, which POSTed the active buffer to a remote HTTP endpoint and opened the response URL via [window.open(r.url, '_blank')](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) -- without noopener/noreferrer or origin allow-listing. It had no menu entry ([internalName:'graphicDiagram'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) so it was unreachable, but remained compiled into the bundle. Removed the method, the orphaned [diagram](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) field from the [Endpoints](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface, and the [diagram](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) value from [environment.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

CVSS 3.1 - 4.3 :: AV:A/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N

Type of change
 Bug fix (non-breaking change which fixes an issue)
PR Checklist
 This PR targets the "staging" branch (v2.x/staging).
 Relevant update to [CHANGELOG.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 My changes generate no new warnings
Testing
Load the editor; confirm all existing menu actions work and no menu item is missing. Grep confirms no remaining [graphicDiagram](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[ENDPOINTS.diagram](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) references.