### PR TITLE
Escape USS names via JSON.stringify in open-in-new-tab and permalink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zlux Editor Changelog
 
+## `2.18.6`
+
+- Bugfix: Fixed a JSON injection flaw in "Open in new tab" and "Copy permalink" where USS file/directory names containing `"` or `\` were concatenated directly into the launch payload string. Crafted names could override the `type`/`name`/`lines` keys and cause a different file or dataset to be opened than displayed. The payload is now built with `JSON.stringify`, which properly escapes special characters.
+
 ## `3.0.1`
  
 - Bugfix: Added a few rules for JCL syntax highlighter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## `2.18.6`
 
-- Bugfix: Fixed a JSON injection flaw in "Open in new tab" and "Copy permalink" where USS file/directory names containing `"` or `\` were concatenated directly into the launch payload string. Crafted names could override the `type`/`name`/`lines` keys and cause a different file or dataset to be opened than displayed. The payload is now built with `JSON.stringify`, which properly escapes special characters.
+- Bugfix: Fixed a JSON injection flaw in "Open in new tab" and "Copy permalink" where USS file/directory names containing `"` or `\` were concatenated directly into the launch payload string. Crafted names could override the `type`/`name`/`lines` keys and cause a different file or dataset to be opened than displayed. ([#408](https://github.com/zowe/zlux-editor/pull/408))
 
 ## `3.0.1`
  

--- a/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.component.ts
@@ -270,10 +270,10 @@ export class MonacoComponent implements OnInit, OnChanges {
       let link = '';
       if(activeFile.model.isDataset){
         filePath = activeFile.model.path;
-        link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openDataset","name":"${filePath}","lines":"${lines}","toggleTree":true}`)}`;
+        link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(JSON.stringify({ type: 'openDataset', name: filePath, lines: `${lines}`, toggleTree: true }))}`;
       } else {
         filePath = activeFile.model.path + "/" + activeFile.model.name;
-        link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openFile","name":"${filePath}","lines":"${lines}","toggleTree":true}`)}`;
+        link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(JSON.stringify({ type: 'openFile', name: filePath, lines: `${lines}`, toggleTree: true }))}`;
       }
       navigator.clipboard.writeText(link).then(() => {
         this.log.debug("Permalink copied to clipboard");

--- a/webClient/src/app/editor/project-tree/project-tree.component.ts
+++ b/webClient/src/app/editor/project-tree/project-tree.component.ts
@@ -234,11 +234,11 @@ export class ProjectTreeComponent {
   onOpenInNewTab($event: any){
     if ($event.data === 'File'){
       const baseURI = `${window.location.origin}${window.location.pathname}`;
-      const newWindow = window.open(`${baseURI}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openFile","name":"${$event.path}","toggleTree":true}`)}`, '_blank');
+      const newWindow = window.open(`${baseURI}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(JSON.stringify({ type: 'openFile', name: $event.path, toggleTree: true }))}`, '_blank');
       newWindow.focus();
     } else{
       const baseURI = `${window.location.origin}${window.location.pathname}`;
-      const newWindow = window.open(`${baseURI}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openDataset","name":"${$event.data.path}","toggleTree":true}`)}`, '_blank');
+      const newWindow = window.open(`${baseURI}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(JSON.stringify({ type: 'openDataset', name: $event.data.path, toggleTree: true }))}`, '_blank');
       newWindow.focus();
     }
 }


### PR DESCRIPTION
Proposed changes
Fixes JSON injection in "Open in new tab" and "Copy permalink". USS names containing "/\ were concatenated into a JSON string before [encodeURIComponent](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), letting a crafted name inject duplicate [type](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[name](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[lines](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) keys so AppComponent.handleLaunchOrMessageObject opened a different file/dataset than displayed. The payload is now built with [JSON.stringify](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (proper escaping) at all four sites in [project-tree.component.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [monaco.component.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

CVSS 3.1 - 4.6 :: AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:N

Type of change
 Bug fix (non-breaking change which fixes an issue)
PR Checklist
 This PR targets the "staging" branch (v2.x/staging).
 Relevant update to [CHANGELOG.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 My changes generate no new warnings
Testing
Open/permalink a benign USS file and a dataset -> correct target opens. With a crafted name (e.g. [x","type":"openFile","name":"/etc/shadow](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)), the launched [name](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is the literal crafted string (escaped), not the injected target.