### PR TITLE
Fix tab switching not updating editor content due to model URI mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## `3.6.0`
 
-- Bugfix: Fixed switching editor tabs not updating the displayed content (the previously active buffer stayed on screen). `fileDuplicateChecker` compared the raw `generateUri()` string while models are created and looked up via `monaco.Uri.parse()`, so an already-open buffer was misdetected as new and `createModel()` threw "model already exists", preventing `setModel()`. The duplicate check now normalizes the URI the same way.
-
+- Bugfix: Fixed switching editor tabs not updating the displayed content (the previously active buffer stayed on screen) ([#410](https://github.com/zowe/zlux-editor/pull/410))
 - Bugfix: Changed initialization of menu action and disabled functions. Now, functions are used as opposed to strings that were evaluated into functions. ([#401](https://github.com/zowe/zlux-editor/pull/401))
 - Bugfix: Hardened the language server (LSP) configuration to demand "wss://" urls rather than permitting "ws://". ([#400](https://github.com/zowe/zlux-editor/pull/400))
 - Bugfix: Fixed a JSON injection flaw in "Open in new tab" and "Copy permalink" where USS file/directory names containing `"` or `\` were concatenated directly into the launch payload string. Crafted names could override the `type`/`name`/`lines` keys and cause a different file or dataset to be opened than displayed. ([#396](https://github.com/zowe/zlux-editor/pull/396))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `3.6.0`
 
+- Bugfix: Fixed switching editor tabs not updating the displayed content (the previously active buffer stayed on screen). `fileDuplicateChecker` compared the raw `generateUri()` string while models are created and looked up via `monaco.Uri.parse()`, so an already-open buffer was misdetected as new and `createModel()` threw "model already exists", preventing `setModel()`. The duplicate check now normalizes the URI the same way.
+
 - Bugfix: Changed initialization of menu action and disabled functions. Now, functions are used as opposed to strings that were evaluated into functions. ([#401](https://github.com/zowe/zlux-editor/pull/401))
 - Bugfix: Hardened the language server (LSP) configuration to demand "wss://" urls rather than permitting "ws://". ([#400](https://github.com/zowe/zlux-editor/pull/400))
 - Bugfix: Fixed a JSON injection flaw in "Open in new tab" and "Copy permalink" where USS file/directory names containing `"` or `\` were concatenated directly into the launch payload string. Crafted names could override the `type`/`name`/`lines` keys and cause a different file or dataset to be opened than displayed. ([#396](https://github.com/zowe/zlux-editor/pull/396))

--- a/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
+++ b/webClient/src/app/editor/code-editor/monaco/monaco.service.ts
@@ -749,9 +749,16 @@ export class MonacoService implements OnDestroy {
   }
 
   fileDuplicateChecker(uri: string): boolean {
+    // Normalize the incoming uri the same way models are created/looked up
+    // (via monaco.Uri.parse). Models are registered under their parsed
+    // Uri.toString(), which can differ from the raw generateUri() string;
+    // comparing the raw string here would miss an existing model and cause
+    // createModel() to throw "model already exists", leaving the editor on
+    // the previous buffer when switching tabs.
+    const normalizedUri = monaco.Uri.parse(uri).toString();
     const models = this.editorControl.editorCore.getValue().editor.getModels();
     for (const model of models) {
-      if (model.uri.toString() === uri) {
+      if (model.uri.toString() === normalizedUri) {
         return true;
       }
     }


### PR DESCRIPTION
## Proposed changes

This PR fixes a regression where switching between editor tabs did not update the displayed content -- the editor kept showing the **previously active** buffer even though a different tab was selected. It reproduces deterministically in a fresh session, for both USS files and MVS datasets/members.

**Root cause:** In `setMonacoModel` (monaco.service.ts), models are created and looked up via `monaco.Uri.parse(model.uri)` (a change introduced to give the reference/label provider a proper `Uri` with a defined `fsPath`). However, `fileDuplicateChecker()` was left comparing the **raw** `generateUri()` string against `model.uri.toString()`. Because Monaco registers models under their parsed `Uri.toString()` (which can differ from the raw string), the duplicate check returned `false` for a buffer that was already open. `setMonacoModel` then took the "not a duplicate" branch and called `editorCore.createModel(...)` with a URI that already existed, which makes Monaco throw *"Cannot add model because it already exists"*. That exception aborted the observable chain **before** `editor.setModel(newModel)` ran, so the editor stayed attached to the previous model -- hence the stale content on tab switch.

**Fix:** `fileDuplicateChecker()` now normalizes the incoming URI the same way models are created/looked up (`monaco.Uri.parse(uri).toString()`) before comparing. The already-open buffer is correctly detected, `getModel(...)` returns the existing model, and `setModel(...)` runs -- so the buffer switches as expected.

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

1. Build the editor: `cd zlux-editor/webClient && npm run build` -- compiles cleanly with no new warnings.
2. In a fresh editor session, open two or more **USS files** and click between their tabs -- confirm the editor content updates to match the selected tab each time.
3. Repeat with **datasets / PDS members** (including names with special characters such as `(MEMBER)`), confirming content switches correctly.
4. Mix USS and MVS tabs and switch back and forth; open, close, and reopen a file, then switch tabs -- content should always reflect the active tab.
5. Regression check for the original AT-TLS change: confirm Go-to-Definition / Find-All-References still resolve (the `fsPath`-related behavior that prompted the `monaco.Uri.parse` change is unaffected).

## Further comments

The underlying issue is an inconsistency introduced when model creation/lookup switched from raw strings to parsed `monaco.Uri` objects without updating the duplicate check. Normalizing in `fileDuplicateChecker` is the minimal, low-risk fix and keeps a single source of truth for URI comparison. A slightly larger alternative would be to drop `fileDuplicateChecker` entirely and rely on `editorCore.getModel(monaco.Uri.parse(model.uri))` directly (returning the existing model if found, else `createModel`), which removes the redundant model-list scan; I kept the smaller change to minimize blast radius, but I'm happy to refactor to that form if maintainers prefer. No automated test was added since the editor lacks a Monaco integration harness; if desired, a unit test around `fileDuplicateChecker` asserting that a raw `generateUri()` string matches an existing parsed-`Uri` model would lock in the fix.